### PR TITLE
Added the azure openai proxy resource endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add support for Azure OpenAI. The plugin must be configured to use OpenAI and provide a link between OpenAI model names and Azure deployment names
+
 ## 0.2.1
 
 * Change path handling for chat completions streams to put separate requests into separate streams. Requests can pass a UUID as the suffix of the path now, but is backwards compatible with an older version of the frontend code.

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -36,6 +36,7 @@
     "llms",
     "nolint",
     "openai",
+    "proxied",
     "proxying",
     "qdrant",
     "testid",

--- a/pkg/plugin/app.go
+++ b/pkg/plugin/app.go
@@ -34,15 +34,16 @@ func NewApp(ctx context.Context, appSettings backend.AppInstanceSettings) (insta
 	log.DefaultLogger.Debug("Creating new app instance")
 	var app App
 
+	log.DefaultLogger.Debug("Loading settings")
+	settings := loadSettings(appSettings)
+
 	// Use a httpadapter (provided by the SDK) for resource calls. This allows us
 	// to use a *http.ServeMux for resource calls, so we can map multiple routes
 	// to CallResource without having to implement extra logic.
 	mux := http.NewServeMux()
-	app.registerRoutes(mux)
+	app.registerRoutes(mux, settings)
 	app.CallResourceHandler = httpadapter.New(mux)
 
-	log.DefaultLogger.Debug("Loading settings")
-	settings := loadSettings(appSettings)
 	var err error
 
 	if settings.Vector.Enabled {

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -78,6 +78,7 @@ func newAzureOpenAIProxy() http.Handler {
 		req.URL.Scheme = "https"
 		req.URL.Host = fmt.Sprintf("%s.openai.azure.com", requestBody["resource"])
 		req.URL.Path = fmt.Sprintf("/openai/deployments/%s/chat/completions", requestBody["deployment"])
+		req.URL.RawQuery = "api-version=2023-03-15-preview"
 		req.Header.Add("api-key", settings.OpenAI.apiKey)
 
 		// Remove extra fields

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -93,7 +93,6 @@ func newOpenAIProxy() http.Handler {
 			req.Header.Add("Authorization", "Bearer "+settings.OpenAI.apiKey)
 			req.Header.Add("OpenAI-Organization", settings.OpenAI.OrganizationID)
 		}
-		log.DefaultLogger.Info(fmt.Sprintf("UUUUUUURL: %+v", req.URL))
 	}
 	return &httputil.ReverseProxy{Director: director}
 }

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -76,13 +76,12 @@ func newAzureOpenAIProxy() http.Handler {
 		json.Unmarshal(bodyBytes, &requestBody)
 
 		req.URL.Scheme = "https"
-		req.URL.Host = fmt.Sprintf("%s.openai.azure.com", requestBody["resource"])
+		req.URL.Host = fmt.Sprintf("%s.openai.azure.com", settings.AzureOpenAI.ResourceName)
 		req.URL.Path = fmt.Sprintf("/openai/deployments/%s/chat/completions", requestBody["deployment"])
 		req.URL.RawQuery = "api-version=2023-03-15-preview"
-		req.Header.Add("api-key", settings.OpenAI.apiKey)
+		req.Header.Add("api-key", settings.AzureOpenAI.apiKey)
 
 		// Remove extra fields
-		delete(requestBody, "resource")
 		delete(requestBody, "deployment")
 
 		newBodyBytes, _ := json.Marshal(requestBody)

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -12,19 +12,98 @@ import (
 
 	"github.com/grafana/grafana-llm-app/pkg/plugin/vector/store"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 )
 
-func mapAzureOpenAIRequest(req *http.Request, settings Settings) error {
-	bodyBytes, _ := io.ReadAll(req.Body)
-	var requestBody map[string]interface{}
-	err := json.Unmarshal(bodyBytes, &requestBody)
+// modifyURL modifies the request URL to point to the configured OpenAI API.
+func modifyURL(openAI OpenAISettings, req *http.Request) error {
+	u, err := url.Parse(openAI.URL)
 	if err != nil {
-		return fmt.Errorf("Unable to unmarshal request body: %w", err)
+		log.DefaultLogger.Error("Unable to parse OpenAI URL", "err", err)
+		return fmt.Errorf("parse OpenAI URL: %w", err)
+	}
+	req.URL.Scheme = u.Scheme
+	req.URL.Host = u.Host
+	return nil
+}
+
+// openAIProxy is a reverse proxy for OpenAI API calls.
+// It modifies the request to point to the configured OpenAI API, returning
+// a 400 error if the URL in settings cannot be parsed, then proxies the request
+// using the configured API key and OpenAI organization.
+type openAIProxy struct {
+	settings Settings
+	// rp is a reverse proxy handling the modified request. Use this rather than
+	// our own client, since it handles things like buffering.
+	rp *httputil.ReverseProxy
+}
+
+func (a *openAIProxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	err := modifyURL(a.settings.OpenAI, req)
+	if err != nil {
+		// Attempt to write the error as JSON.
+		jd, err := json.Marshal(map[string]string{"error": err.Error()})
+		if err != nil {
+			// We can't write JSON, so just write the error string.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, err = w.Write([]byte(err.Error()))
+			if err != nil {
+				log.DefaultLogger.Error("Unable to write error response", "err", err)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, err = w.Write(jd)
+		if err != nil {
+			log.DefaultLogger.Error("Unable to write error response", "err", err)
+		}
+	}
+	a.rp.ServeHTTP(w, req)
+}
+
+func newOpenAIProxy(settings Settings) http.Handler {
+	director := func(req *http.Request) {
+		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/openai")
+		req.Header.Add("Authorization", "Bearer "+settings.OpenAI.apiKey)
+		req.Header.Add("OpenAI-Organization", settings.OpenAI.OrganizationID)
+	}
+	return &openAIProxy{
+		settings: settings,
+		rp:       &httputil.ReverseProxy{Director: director},
+	}
+}
+
+// azureOpenAIProxy is a reverse proxy for Azure OpenAI API calls.
+// It modifies the request to point to the configured Azure OpenAI API, returning
+// a 400 error if the URL in settings cannot be parsed or if the request refers
+// to a model without a corresponding deployment in settings. It then proxies the request
+// using the configured API key and deployment.
+type azureOpenAIProxy struct {
+	settings Settings
+	// rp is a reverse proxy handling the modified request. Use this rather than
+	// our own client, since it handles things like buffering.
+	rp *httputil.ReverseProxy
+}
+
+func (a *azureOpenAIProxy) modifyRequest(req *http.Request) error {
+	err := modifyURL(a.settings.OpenAI, req)
+	if err != nil {
+		return fmt.Errorf("modify url: %w", err)
 	}
 
+	// Read the body so we can determine the deployment to use
+	// by mapping the model in the request to a deployment in settings.
+	// Azure OpenAI API requires this deployment name in the URL.
+	bodyBytes, _ := io.ReadAll(req.Body)
+	var requestBody map[string]interface{}
+	err = json.Unmarshal(bodyBytes, &requestBody)
+	if err != nil {
+		return fmt.Errorf("unmarshal request body: %w", err)
+	}
+
+	// Find the deployment for the model.
+	// Models are mapped to deployments in settings.OpenAI.AzureMapping.
 	var deployment string = ""
-	for _, v := range settings.OpenAI.AzureMapping {
+	for _, v := range a.settings.OpenAI.AzureMapping {
 		if val, ok := requestBody["model"].(string); ok && val == v[0] {
 			deployment = v[1]
 			break
@@ -32,11 +111,12 @@ func mapAzureOpenAIRequest(req *http.Request, settings Settings) error {
 	}
 
 	if deployment == "" {
-		return fmt.Errorf("No deployment found for model: %s", requestBody["model"])
+		return fmt.Errorf("no deployment found for model: %s", requestBody["model"])
 	}
 
-	req.URL.Path = fmt.Sprintf("/openai/deployments/%s/%s", deployment, strings.TrimPrefix(req.URL.Path, "/openai/v1"))
-	req.Header.Add("api-key", settings.OpenAI.apiKey)
+	// We've got a deployment, so finish modifying the request.
+	req.URL.Path = fmt.Sprintf("/openai/deployments/%s/%s", deployment, strings.TrimPrefix(req.URL.Path, "/openai/v1/"))
+	req.Header.Add("api-key", a.settings.OpenAI.apiKey)
 	req.URL.RawQuery = "api-version=2023-03-15-preview"
 
 	// Remove extra fields
@@ -44,47 +124,47 @@ func mapAzureOpenAIRequest(req *http.Request, settings Settings) error {
 
 	newBodyBytes, err := json.Marshal(requestBody)
 	if err != nil {
-		return fmt.Errorf("Unable to unmarshal request body: %w", err)
+		return fmt.Errorf("unmarshal request body: %w", err)
 	}
 	req.Body = io.NopCloser(bytes.NewBuffer(newBodyBytes))
 	req.ContentLength = int64(len(newBodyBytes))
-
 	return nil
 }
 
-func newOpenAIProxy() http.Handler {
-	director := func(req *http.Request) {
-		config := httpadapter.PluginConfigFromContext(req.Context())
-		settings := loadSettings(*config.AppInstanceSettings)
-		hasError := false
-		errorMsg := ""
-
-		u, err := url.Parse(settings.OpenAI.URL)
-		req.URL.Scheme = u.Scheme
-		req.URL.Host = u.Host
-
+func (a *azureOpenAIProxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	err := a.modifyRequest(req)
+	if err != nil {
+		// Attempt to write the error as JSON.
+		jd, err := json.Marshal(map[string]string{"error": err.Error()})
 		if err != nil {
-			hasError = true
-			errorMsg = fmt.Sprintf("Unable to parse OpenAI URL: %s", err)
-		}
-
-		if settings.OpenAI.UseAzure && !hasError {
-			err := mapAzureOpenAIRequest(req, settings)
+			// We can't write JSON, so just write the error string.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, err = w.Write([]byte(err.Error()))
 			if err != nil {
-				hasError = true
-				errorMsg = err.Error()
+				log.DefaultLogger.Error("Unable to write error response", "err", err)
 			}
-		} else {
-			req.URL.Path = strings.TrimPrefix(req.URL.Path, "/openai")
-			req.Header.Add("Authorization", "Bearer "+settings.OpenAI.apiKey)
-			req.Header.Add("OpenAI-Organization", settings.OpenAI.OrganizationID)
+			return
 		}
-
-		if hasError {
-			log.DefaultLogger.Error(fmt.Sprintf("Proxy error: %s", errorMsg))
+		w.WriteHeader(http.StatusBadRequest)
+		_, err = w.Write(jd)
+		if err != nil {
+			log.DefaultLogger.Error("Unable to write error response", "err", err)
 		}
+		return
 	}
-	return &httputil.ReverseProxy{Director: director}
+	a.rp.ServeHTTP(w, req)
+}
+
+func newAzureOpenAIProxy(settings Settings) http.Handler {
+	// We make all of the actual modifications in ServeHTTP, since they can fail
+	// and we want to early-return from HTTP requests in that case.
+	director := func(req *http.Request) {}
+	return &azureOpenAIProxy{
+		settings: settings,
+		rp: &httputil.ReverseProxy{
+			Director: director,
+		},
+	}
 }
 
 type vectorSearchRequest struct {
@@ -130,7 +210,11 @@ func (app *App) handleVectorSearch(w http.ResponseWriter, req *http.Request) {
 }
 
 // registerRoutes takes a *http.ServeMux and registers some HTTP handlers.
-func (a *App) registerRoutes(mux *http.ServeMux) {
-	mux.Handle("/openai/", newOpenAIProxy())
+func (a *App) registerRoutes(mux *http.ServeMux, settings Settings) {
+	if settings.OpenAI.UseAzure {
+		mux.Handle("/openai/", newAzureOpenAIProxy(settings))
+	} else {
+		mux.Handle("/openai/", newOpenAIProxy(settings))
+	}
 	mux.HandleFunc("/vector/search", a.handleVectorSearch)
 }

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -26,7 +26,7 @@ func newOpenAIProxy() http.Handler {
 
 		if settings.OpenAI.UseAzure {
 			// Map model to deployment
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			var requestBody map[string]interface{}
 			json.Unmarshal(bodyBytes, &requestBody)
 
@@ -51,7 +51,7 @@ func newOpenAIProxy() http.Handler {
 			delete(requestBody, "model")
 
 			newBodyBytes, _ := json.Marshal(requestBody)
-			req.Body = ioutil.NopCloser(bytes.NewBuffer(newBodyBytes))
+			req.Body = io.NopCloser(bytes.NewBuffer(newBodyBytes))
 			req.ContentLength = int64(len(newBodyBytes))
 		} else {
 			req.URL.Path = strings.TrimPrefix(req.URL.Path, "/openai")

--- a/pkg/plugin/resources_test.go
+++ b/pkg/plugin/resources_test.go
@@ -3,7 +3,9 @@ package plugin
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -70,6 +72,190 @@ func TestCallResource(t *testing.T) {
 			if r.response == nil {
 				t.Fatal("no response received from CallResource")
 			}
+			if tc.expStatus > 0 && tc.expStatus != r.response.Status {
+				t.Errorf("response status should be %d, got %d", tc.expStatus, r.response.Status)
+			}
+			if len(tc.expBody) > 0 {
+				if tb := bytes.TrimSpace(r.response.Body); !bytes.Equal(tb, tc.expBody) {
+					t.Errorf("response body should be %s, got %s", tc.expBody, tb)
+				}
+			}
+		})
+	}
+}
+
+type mockServer struct {
+	server  *httptest.Server
+	request *http.Request
+}
+
+func newMockOpenAIServer(t *testing.T) *mockServer {
+	server := &mockServer{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server.request = r
+		w.WriteHeader(http.StatusOK)
+	})
+	server.server = httptest.NewServer(handler)
+	return server
+}
+
+func TestCallOpenAIProxy(t *testing.T) {
+	// Set up and run test cases
+	for _, tc := range []struct {
+		name string
+
+		openAIsettings OpenAISettings
+		apiKey         string
+
+		method string
+		path   string
+		body   []byte
+
+		// Expected proxied request values.
+		expNilRequest bool
+		expReqHeaders http.Header
+		expReqPath    string
+		expReqBody    []byte
+
+		// Expected proxied response values.
+		expStatus int
+		expBody   []byte
+	}{
+		{
+			name: "openai",
+
+			openAIsettings: OpenAISettings{
+				OrganizationID: "myOrg",
+				UseAzure:       false,
+			},
+			apiKey: "abcd1234",
+
+			method: http.MethodPost,
+			path:   "/openai/v1/chat/completions",
+			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
+
+			expReqHeaders: http.Header{
+				"Authorization":       {"Bearer abcd1234"},
+				"OpenAI-Organization": {"myOrg"},
+			},
+			expReqPath: "/v1/chat/completions",
+			expReqBody: []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
+
+			expStatus: http.StatusOK,
+		},
+		{
+			name: "azure",
+
+			openAIsettings: OpenAISettings{
+				OrganizationID: "myOrg",
+				UseAzure:       true,
+				AzureMapping: [][]string{
+					{"gpt-3.5-turbo", "gpt-35-turbo"},
+				},
+			},
+			apiKey: "abcd1234",
+
+			method: http.MethodPost,
+			path:   "/openai/v1/chat/completions",
+			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
+
+			expReqHeaders: http.Header{
+				"api-key": {"abcd1234"},
+			},
+			expReqPath: "/openai/deployments/gpt-35-turbo/chat/completions",
+			// the 'model' field should have been removed.
+			expReqBody: []byte(`{"messages":["some stuff"]}`),
+
+			expStatus: http.StatusOK,
+		},
+		{
+			name: "azure invalid deployment",
+
+			openAIsettings: OpenAISettings{
+				OrganizationID: "myOrg",
+				UseAzure:       true,
+				AzureMapping: [][]string{
+					{"gpt-3.5-turbo", "gpt-35-turbo"},
+				},
+			},
+			apiKey: "abcd1234",
+
+			method: http.MethodPost,
+			path:   "/openai/v1/chat/completions",
+			// note no gpt-4 in AzureMapping.
+			body: []byte(`{"model": "gpt-4", "messages": ["some stuff"]}`),
+
+			expNilRequest: true,
+
+			expStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			// Start up a mock server that just captures the request and sends a 200 OK response.
+			server := newMockOpenAIServer(t)
+
+			// Update the OpenAI URL with the mock server's URL.
+			tc.openAIsettings.URL = server.server.URL
+
+			// Initialize app
+			settings := Settings{OpenAI: tc.openAIsettings}
+			jsonData, err := json.Marshal(settings)
+			if err != nil {
+				t.Fatalf("json marshal: %s", err)
+			}
+			appSettings := backend.AppInstanceSettings{
+				JSONData: jsonData,
+				DecryptedSecureJSONData: map[string]string{
+					"openAIKey": tc.apiKey,
+				},
+			}
+			inst, err := NewApp(ctx, appSettings)
+			if err != nil {
+				t.Fatalf("new app: %s", err)
+			}
+			if inst == nil {
+				t.Fatal("inst must not be nil")
+			}
+			app, ok := inst.(*App)
+			if !ok {
+				t.Fatal("inst must be of type *App")
+			}
+
+			var r mockCallResourceResponseSender
+			err = app.CallResource(ctx, &backend.CallResourceRequest{
+				PluginContext: backend.PluginContext{
+					AppInstanceSettings: &appSettings,
+				},
+				Method: tc.method,
+				Path:   tc.path,
+				Body:   tc.body,
+			}, &r)
+			if err != nil {
+				t.Fatalf("CallResource error: %s", err)
+			}
+			if r.response == nil {
+				t.Fatal("no response received from CallResource")
+			}
+
+			// Proxied request assertions.
+			if tc.expNilRequest && server.request != nil {
+				t.Fatalf("request should not have been proxied, got %v", server.request)
+			}
+			if len(tc.expReqHeaders) > 0 {
+				for k, values := range tc.expReqHeaders {
+					if got := server.request.Header.Get(k); got != values[0] {
+						t.Errorf("proxied request header %s should have value %s, got %s", k, values[0], got)
+					}
+				}
+			}
+			if tc.expReqPath != "" {
+				if server.request.URL.Path != tc.expReqPath {
+					t.Errorf("proxied request path should be %s, got %s", tc.expReqPath, server.request.URL.Path)
+				}
+			}
+
+			// Response assertions.
 			if tc.expStatus > 0 && tc.expStatus != r.response.Status {
 				t.Errorf("response status should be %d, got %d", tc.expStatus, r.response.Status)
 			}

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -10,10 +10,10 @@ import (
 const openAIKey = "openAIKey"
 
 type OpenAISettings struct {
-	URL            string            `json:"url"`
-	OrganizationID string            `json:"organizationId"`
-	UseAzure       bool              `json:"useAzure"`
-	AzureMapping   map[string]string `json:"azureOpenAIModelMapping"`
+	URL            string     `json:"url"`
+	OrganizationID string     `json:"organizationId"`
+	UseAzure       bool       `json:"useAzure"`
+	AzureMapping   [][]string `json:"azureModelMapping"`
 	apiKey         string
 }
 

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -8,6 +8,7 @@ import (
 )
 
 const openAIKey = "openAIKey"
+const azureOpenAIKey = "azureOpenAIKey"
 
 type OpenAISettings struct {
 	URL            string `json:"url"`
@@ -15,8 +16,14 @@ type OpenAISettings struct {
 	apiKey         string
 }
 
+type AzureOpenAISettings struct {
+	ResourceName string `json:"resource"`
+	apiKey       string
+}
+
 type Settings struct {
-	OpenAI OpenAISettings `json:"openAI"`
+	OpenAI      OpenAISettings      `json:"openAI"`
+	AzureOpenAI AzureOpenAISettings `json:"azureOpenAI"`
 
 	Vector vector.VectorSettings `json:"vector"`
 }
@@ -30,5 +37,6 @@ func loadSettings(appSettings backend.AppInstanceSettings) Settings {
 	_ = json.Unmarshal(appSettings.JSONData, &settings)
 
 	settings.OpenAI.apiKey = appSettings.DecryptedSecureJSONData[openAIKey]
+	settings.AzureOpenAI.apiKey = appSettings.DecryptedSecureJSONData[azureOpenAIKey]
 	return settings
 }

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -12,7 +12,7 @@ const openAIKey = "openAIKey"
 type OpenAISettings struct {
 	URL            string            `json:"url"`
 	OrganizationID string            `json:"organizationId"`
-	UseAzure       bool              `json:"azureOpenAI"`
+	UseAzure       bool              `json:"useAzure"`
 	AzureMapping   map[string]string `json:"azureOpenAIModelMapping"`
 	apiKey         string
 }

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -8,22 +8,17 @@ import (
 )
 
 const openAIKey = "openAIKey"
-const azureOpenAIKey = "azureOpenAIKey"
 
 type OpenAISettings struct {
-	URL            string `json:"url"`
-	OrganizationID string `json:"organizationId"`
+	URL            string            `json:"url"`
+	OrganizationID string            `json:"organizationId"`
+	UseAzure       bool              `json:"azureOpenAI"`
+	AzureMapping   map[string]string `json:"azureOpenAIModelMapping"`
 	apiKey         string
 }
 
-type AzureOpenAISettings struct {
-	ResourceName string `json:"resource"`
-	apiKey       string
-}
-
 type Settings struct {
-	OpenAI      OpenAISettings      `json:"openAI"`
-	AzureOpenAI AzureOpenAISettings `json:"azureOpenAI"`
+	OpenAI OpenAISettings `json:"openAI"`
 
 	Vector vector.VectorSettings `json:"vector"`
 }
@@ -37,6 +32,5 @@ func loadSettings(appSettings backend.AppInstanceSettings) Settings {
 	_ = json.Unmarshal(appSettings.JSONData, &settings)
 
 	settings.OpenAI.apiKey = appSettings.DecryptedSecureJSONData[openAIKey]
-	settings.AzureOpenAI.apiKey = appSettings.DecryptedSecureJSONData[azureOpenAIKey]
 	return settings
 }

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -70,7 +70,7 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 		delete(requestBody, "model")
 
 	} else {
-		u.Path = strings.TrimPrefix(req.Path, "openai")
+		u.Path = "/v1/chat/completions"
 	}
 
 	outgoingBody, err = json.Marshal(requestBody)

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -14,7 +14,6 @@ import (
 )
 
 const openAIChatCompletionsPath = "openai/v1/chat/completions"
-const azureOpenAIChatCompletionsPath = "azure/completions"
 
 type chatCompletionsMessage struct {
 	Role    string `json:"role"`
@@ -33,7 +32,7 @@ func (a *App) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamR
 	resp := &backend.SubscribeStreamResponse{
 		Status: backend.SubscribeStreamStatusNotFound,
 	}
-	if req.Path == openAIChatCompletionsPath || req.Path == azureOpenAIChatCompletionsPath {
+	if req.Path == openAIChatCompletionsPath {
 		resp.Status = backend.SubscribeStreamStatusOK
 	}
 	return resp, nil
@@ -136,7 +135,7 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 
 func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	log.DefaultLogger.Debug(fmt.Sprintf("RunStream: %s", req.Path), "data", string(req.Data))
-	if req.Path == openAIChatCompletionsPath || req.Path == azureOpenAIChatCompletionsPath {
+	if req.Path == openAIChatCompletionsPath {
 		return a.runOpenAIChatCompletionsStream(ctx, req, sender)
 	}
 	return fmt.Errorf("unknown stream path: %s", req.Path)

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -46,7 +46,7 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 
 	if err != nil {
 		return fmt.Errorf("Unable to parse OpenAI URL: %w", err)
-	
+	}
 
 	var outgoingBody []byte
 

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -34,7 +34,6 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 	requestBody := map[string]interface{}{}
 	var err error
 	err = json.Unmarshal(req.Data, &requestBody)
-
 	if err != nil {
 		return fmt.Errorf("Unable to unmarshal request body: %w", err)
 	}
@@ -43,7 +42,6 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 	requestBody["stream"] = true
 
 	u, err := url.Parse(settings.OpenAI.URL)
-
 	if err != nil {
 		return fmt.Errorf("Unable to parse OpenAI URL: %w", err)
 	}
@@ -76,6 +74,9 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 	}
 
 	outgoingBody, err = json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("Unable to marshal new request body: %w", err)
+	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(outgoingBody))
 	if err != nil {
 		return fmt.Errorf("proxy: stream: error creating request: %w", err)

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -73,7 +73,6 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 		u.Path = "/v1/chat/completions"
 	}
 
-	log.DefaultLogger.Info(fmt.Sprintf("requestBody: %s; url: %s", requestBody, u.String()))
 	outgoingBody, err = json.Marshal(requestBody)
 	if err != nil {
 		return fmt.Errorf("Unable to marshal new request body: %w", err)

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -42,7 +42,11 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 	// set stream to true
 	requestBody["stream"] = true
 
-	u, _ := url.Parse(settings.OpenAI.URL)
+	u, err := url.Parse(settings.OpenAI.URL)
+
+	if err != nil {
+		return fmt.Errorf("Unable to parse OpenAI URL: %w", err)
+	
 
 	var outgoingBody []byte
 

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -69,8 +69,7 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 		}
 
 		if deployment == "" {
-			log.DefaultLogger.Error(fmt.Sprintf("No deployment found for model: %s", requestBody["model"]))
-			deployment = "DEPLOYMENT_IS_MISSING"
+			return fmt.Errorf("No deployment found for model: %s", requestBody["model"])
 		}
 
 		u.Path = fmt.Sprintf("/openai/deployments/%s/chat/completion", deployment)

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -16,17 +16,6 @@ import (
 
 const openAIChatCompletionsPath = "openai/v1/chat/completions"
 
-type chatCompletionsMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-}
-
-// type chatCompletionsRequest struct {
-// 	Model    string                   `json:"model"`
-// 	Messages []chatCompletionsMessage `json:"messages"`
-// 	Stream   bool                     `json:"stream"`
-// }
-
 func (a *App) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
 	log.DefaultLogger.Debug(fmt.Sprintf("SubscribeStream: %s", req.Path))
 

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -93,7 +93,7 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 	lastEventID := "" // no last event id
 	eventStream, err := eventsource.SubscribeWithRequest(lastEventID, httpReq)
 	if err != nil {
-		return fmt.Errorf("proxy: stream: eventsource.SubscribeWithRequest: %+v: %w", httpReq, err)
+		return fmt.Errorf("proxy: stream: eventsource.SubscribeWithRequest: %s: %w", httpReq.URL, err)
 	}
 	defer func() {
 		eventStream.Close()

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -14,6 +14,7 @@ import (
 )
 
 const openAIChatCompletionsPath = "openai/v1/chat/completions"
+const azureOpenAIChatCompletionsPath = "azure/completions"
 
 type chatCompletionsMessage struct {
 	Role    string `json:"role"`
@@ -32,7 +33,7 @@ func (a *App) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamR
 	resp := &backend.SubscribeStreamResponse{
 		Status: backend.SubscribeStreamStatusNotFound,
 	}
-	if req.Path == openAIChatCompletionsPath {
+	if req.Path == openAIChatCompletionsPath || req.Path == azureOpenAIChatCompletionsPath {
 		resp.Status = backend.SubscribeStreamStatusOK
 	}
 	return resp, nil
@@ -135,7 +136,7 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 
 func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	log.DefaultLogger.Debug(fmt.Sprintf("RunStream: %s", req.Path), "data", string(req.Data))
-	if req.Path == openAIChatCompletionsPath {
+	if req.Path == openAIChatCompletionsPath || req.Path == azureOpenAIChatCompletionsPath {
 		return a.runOpenAIChatCompletionsStream(ctx, req, sender)
 	}
 	return fmt.Errorf("unknown stream path: %s", req.Path)

--- a/provisioning/plugins/grafana-llm-app.yaml
+++ b/provisioning/plugins/grafana-llm-app.yaml
@@ -17,3 +17,4 @@ apps:
 
     secureJsonData:
       openAIKey: $OPENAI_API_KEY
+      azureOpenAIKey: $AZURE_OPENAI_API_KEY

--- a/provisioning/plugins/grafana-llm-app.yaml
+++ b/provisioning/plugins/grafana-llm-app.yaml
@@ -13,7 +13,7 @@ apps:
           qdrant:
             address: qdrant:6334
       azureopenai:
-        url: https://api.openai.com
+        resource: grafana-machine-learning-dev
 
     secureJsonData:
       openAIKey: $OPENAI_API_KEY

--- a/provisioning/plugins/grafana-llm-app.yaml
+++ b/provisioning/plugins/grafana-llm-app.yaml
@@ -12,6 +12,8 @@ apps:
           type: qdrant
           qdrant:
             address: qdrant:6334
+      azureopenai:
+        url: https://api.openai.com
 
     secureJsonData:
       openAIKey: $OPENAI_API_KEY

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -3,14 +3,17 @@ import { lastValueFrom } from 'rxjs';
 import { css } from '@emotion/css';
 import { AppPluginMeta, GrafanaTheme2, PluginConfigPageProps, PluginMeta } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
-import { Button, Field, FieldSet, Input, SecretInput, useStyles2, Switch } from '@grafana/ui';
+import { Button, Field, FieldSet, Input, SecretInput, useStyles2, Switch, InlineField, IconButton, Select, InlineFieldRow } from '@grafana/ui';
 import { testIds } from '../testIds';
 
 type OpenAISettings = {
   url?: string;
   organizationId?: string;
   useAzure?: boolean;
+  azureModelMapping?: ModelDeploymentMap;
 }
+
+type ModelDeploymentMap = Array<[string, string]>;
 
 export type AppPluginSettings = {
   openAI?: OpenAISettings;
@@ -27,11 +30,94 @@ type State = {
   openAIKey: string;
   // A flag to tell us if we should use Azure OpenAI.
   useAzureOpenAI: boolean;
+  // A mapping of Azure models to OpenAI models.
+  azureModelMapping: ModelDeploymentMap;
   // A flag to tell us if state was updated
   updated: boolean;
 };
 
 export interface AppConfigProps extends PluginConfigPageProps<AppPluginMeta<AppPluginSettings>> { }
+
+function ModelMappingConfig({ modelMapping, modelNames, onChange }: {
+  modelMapping: Array<[string, string]>;
+  modelNames: string[];
+  onChange: (modelMapping: Array<[string, string]>) => void;
+}) {
+  return (
+    <>
+      <IconButton
+        name="plus"
+        aria-label="Add model mapping"
+        onClick={e => {
+          e.preventDefault();
+          onChange([...modelMapping, ['', '']]);
+        }}
+      />
+      {modelMapping.map(([model, deployment], i) => (
+        <ModelMappingField
+          key={i}
+          model={model}
+          deployment={deployment}
+          modelNames={modelNames}
+          onChange={(model, deployment) => {
+            onChange([
+              ...modelMapping.slice(0, i),
+              [model, deployment],
+              ...modelMapping.slice(i + 1),
+            ]);
+          }}
+          onRemove={() => onChange([
+            ...modelMapping.slice(0, i),
+            ...modelMapping.slice(i + 1),
+          ])}
+        />
+      )
+      )}
+    </>
+  );
+}
+
+function ModelMappingField({ model, deployment, modelNames, onChange, onRemove }: {
+  model: string;
+  deployment: string;
+  modelNames: string[],
+  onChange: (model: string, deployment: string) => void;
+  onRemove: () => void;
+}): JSX.Element {
+  return (
+    <InlineFieldRow>
+      <InlineField label="Model">
+        <Select
+          placeholder="model label"
+          options={modelNames
+            .filter(n => n !== deployment && n !== '')
+            .map(value => ({ label: value, value }))
+          }
+          value={model}
+          onChange={event => event.value !== undefined && onChange(event.value, deployment)}
+        />
+      </InlineField>
+      <InlineField label="Deployment">
+        <Input
+          width={40} 
+          name="AzureDeployment"
+          placeholder="deployment name"
+          value={deployment}
+          onChange={event => event.currentTarget.value !== undefined && onChange(model, event.currentTarget.value)}
+        />
+      </InlineField>
+      <IconButton
+        name="trash-alt"
+        aria-label="Remove model mapping"
+        onClick={e => {
+          e.preventDefault();
+          onRemove()
+        }}
+      />
+    </InlineFieldRow>
+  );
+}
+
 
 export const AppConfig = ({ plugin }: AppConfigProps) => {
   const s = useStyles2(getStyles);
@@ -42,6 +128,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
     openAIKey: '',
     isOpenAIKeySet: Boolean(secureJsonFields?.openAIKey),
     useAzureOpenAI: jsonData?.openAI?.useAzure || false,
+    azureModelMapping: jsonData?.openAI?.azureModelMapping || [],
     updated: false,
   });
 
@@ -53,6 +140,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
       openAIOrganizationID: '',
       isOpenAIKeySet: false,
       useAzureOpenAI: state.useAzureOpenAI,
+      azureModelMapping: [],
       updated: true,
     });
 
@@ -89,7 +177,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
 
         <Field label="OpenAI API Organization ID" description="Your OpenAI API Organization ID">
           <Input
-            width={60}
+            width={60} 
             name="openAIOrganizationID"
             data-testid={testIds.appConfig.openAIOrganizationID}
             value={state.openAIOrganizationID}
@@ -112,6 +200,22 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
           />
         </Field>
 
+        {state.useAzureOpenAI && (
+          <Field label="Azure OpenAI Model Mapping" description="">
+            <ModelMappingConfig
+              modelMapping={state.azureModelMapping}
+              modelNames={["gpt-3.5-turbo", "gpt-4"]}
+              onChange={
+                azureModelMapping => setState({
+                  ...state,
+                  azureModelMapping,
+                  updated: true,
+                })
+              }
+            />
+          </Field>
+        )}
+
         <div className={s.marginTop}>
           <Button
             type="submit"
@@ -125,6 +229,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
                     url: state.openAIUrl,
                     organizationId: state.openAIOrganizationID,
                     useAzure: state.useAzureOpenAI,
+                    azureModelMapping: state.azureModelMapping,
                   },
                 },
                 // This cannot be queried later by the frontend.

--- a/src/components/testIds.ts
+++ b/src/components/testIds.ts
@@ -1,6 +1,7 @@
 export const testIds = {
   appConfig: {
     container: 'data-testid ac-container',
+    useAzureOpenAI: 'data-testid ac-use-azure-openai',
     openAIKey: 'data-testid ac-openai-api-key',
     openAIOrganizationID: 'data-testid ac-openai-api-organization-id',
     openAIUrl: 'data-testid ac-openai-api-url',


### PR DESCRIPTION
 Implements #55 

Added proxy implementation for Azure OpenAI

User can opt to use Azure OpenAI backend updating the following logics:
- Turn on the Use Azure OpenAI toggle
- Setting the correct URL and corresponding api-key
- Adding the model mapping (each OpenAI model should be mapped to a Azure deployment)

No changes required on the frontend.