### PR TITLE
Move 'enabled' logic of client packages into plugin health check

### DIFF
--- a/pkg/plugin/app.go
+++ b/pkg/plugin/app.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/grafana/grafana-llm-app/pkg/plugin/vector"
@@ -66,13 +65,4 @@ func (a *App) Dispose() {
 	if a.vectorService != nil {
 		a.vectorService.Cancel()
 	}
-}
-
-// CheckHealth handles health checks sent from Grafana to the plugin.
-func (a *App) CheckHealth(_ context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	log.DefaultLogger.Info("check health")
-	return &backend.CheckHealthResult{
-		Status:  backend.HealthStatusOk,
-		Message: "ok",
-	}, nil
 }

--- a/pkg/plugin/health.go
+++ b/pkg/plugin/health.go
@@ -1,0 +1,34 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+type healthCheckResponse struct {
+	OpenAIEnabled bool `json:"openAI"`
+	VectorEnabled bool `json:"vector"`
+}
+
+// CheckHealth handles health checks sent from Grafana to the plugin.
+// It returns whether each feature is enabled based on the plugin settings.
+func (a *App) CheckHealth(_ context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	settings := req.PluginContext.AppInstanceSettings
+	resp := healthCheckResponse{
+		OpenAIEnabled: settings.DecryptedSecureJSONData[openAIKey] != "",
+		VectorEnabled: a.vectorService != nil,
+	}
+	body, err := json.Marshal(resp)
+	if err != nil {
+		return &backend.CheckHealthResult{
+			Status:  backend.HealthStatusError,
+			Message: "failed to marshal response",
+		}, nil
+	}
+	return &backend.CheckHealthResult{
+		Status:      backend.HealthStatusOk,
+		JSONDetails: body,
+	}, nil
+}

--- a/pkg/plugin/health_test.go
+++ b/pkg/plugin/health_test.go
@@ -1,0 +1,127 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+// TestCheckHealth tests CheckHealth calls, using backend.CheckHealthRequest and backend.CheckHealthResponse.
+func TestCheckHealth(t *testing.T) {
+
+	// Set up and run test cases
+	for _, tc := range []struct {
+		name     string
+		settings backend.AppInstanceSettings
+
+		expDetails healthCheckResponse
+	}{
+		{
+			name: "everything disabled",
+			settings: backend.AppInstanceSettings{
+				DecryptedSecureJSONData: map[string]string{},
+			},
+			expDetails: healthCheckResponse{
+				OpenAIEnabled: false,
+				VectorEnabled: false,
+			},
+		},
+		{
+			name: "openai enabled",
+			settings: backend.AppInstanceSettings{
+				DecryptedSecureJSONData: map[string]string{openAIKey: "abcd1234"},
+			},
+			expDetails: healthCheckResponse{
+				OpenAIEnabled: true,
+				VectorEnabled: false,
+			},
+		},
+		{
+			name: "vector enabled, no openai",
+			settings: backend.AppInstanceSettings{
+				JSONData: json.RawMessage(`{
+					"vector": {
+						"enabled": true,
+						"embed": {
+							"type": "openai",
+							"openai": {
+								"url": "http://localhost:3000"
+							}
+						},
+						"store": {
+							"type": "qdrant",
+							"qdrant": {
+								"address": "localhost:6334"
+							}
+						}
+					}
+				}`),
+				DecryptedSecureJSONData: map[string]string{},
+			},
+			expDetails: healthCheckResponse{
+				OpenAIEnabled: false,
+				VectorEnabled: true,
+			},
+		},
+		{
+			name: "vector enabled with openai",
+			settings: backend.AppInstanceSettings{
+				JSONData: json.RawMessage(`{
+					"vector": {
+						"enabled": true,
+						"embed": {
+							"type": "openai"
+						},
+						"store": {
+							"type": "qdrant",
+							"qdrant": {
+								"address": "localhost:6334"
+							}
+						}
+					}
+				}`),
+				DecryptedSecureJSONData: map[string]string{openAIKey: "abcd1234"},
+			},
+			expDetails: healthCheckResponse{
+				OpenAIEnabled: true,
+				VectorEnabled: true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Initialize app
+			inst, err := NewApp(tc.settings)
+			if err != nil {
+				t.Fatalf("new app: %s", err)
+			}
+			if inst == nil {
+				t.Fatal("inst must not be nil")
+			}
+			app, ok := inst.(*App)
+			if !ok {
+				t.Fatal("inst must be of type *App")
+			}
+			// Request by calling CheckHealth.
+			resp, err := app.CheckHealth(context.Background(), &backend.CheckHealthRequest{
+				PluginContext: backend.PluginContext{
+					AppInstanceSettings: &tc.settings,
+				},
+			})
+			if err != nil {
+				t.Fatalf("CheckHealth error: %s", err)
+			}
+			if resp == nil {
+				t.Fatal("no response received from CheckHealth")
+			}
+			var details healthCheckResponse
+			if err = json.Unmarshal(resp.JSONDetails, &details); err != nil {
+				t.Errorf("non-JSON response details (%s): %s", resp.JSONDetails, err)
+			}
+			if details != tc.expDetails {
+				t.Errorf("response details should be %v, got %v", tc.expDetails, details)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This centralises the logic of determining whether each feature of the
plugin is enabled, moving it into the plugin's health check handler.

The /api/plugins/grafana-llm-app/health endpoint will now return
something like this:

```json
{
  "details": {
    "openAI": true,
    "vector": true
  },
  "message": "",
  "status": "OK"
}
```

We can add further fields as we add more features (e.g. Azure OpenAI
support).
