### PR TITLE
Add client library to streamline using go-openai via LLM app

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/grafana/grafana-plugin-sdk-go v0.176.0
 	github.com/launchdarkly/eventsource v1.7.1
 	github.com/qdrant/go-client v1.5.0
+	github.com/sashabaranov/go-openai v1.15.3
 	google.golang.org/grpc v1.58.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -228,6 +228,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
+github.com/sashabaranov/go-openai v1.15.3 h1:rzoNK9n+Cak+PM6OQ9puxDmFllxfnVea9StlmhglXqA=
+github.com/sashabaranov/go-openai v1.15.3/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 h1:Jpy1PXuP99tXNrhbq2BaPz9B+jNAvH1JPQQpG/9GCXY=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// DefaultGrafanaLLMAppConfig creates new OpenAI client config for use
+// when accessing OpenAI via the Grafana LLM App.
+func DefaultGrafanaLLMAppConfig(grafanaURL, grafanaAPIKey string) openai.ClientConfig {
+	url := strings.TrimRight(grafanaURL, "/") + "/api/plugins/grafana-llm-app/resources/openai/v1"
+	cfg := openai.DefaultConfig(grafanaAPIKey)
+	cfg.BaseURL = url
+	return cfg
+}
+
+type healthCheckResponse struct {
+	OpenAIEnabled bool `json:"openAI"`
+	VectorEnabled bool `json:"vector"`
+}
+
+// ErrPluginNotInstalled is returned when the Grafana LLM App plugin is not installed.
+var ErrPluginNotInstalled = errors.New("grafana-llm-app plugin not installed")
+
+func checkHealth(ctx context.Context, grafanaURL, grafanaAPIKey string) (*healthCheckResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", grafanaURL+"/api/plugins/grafana-llm-app/health", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+grafanaAPIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("make request: %w", err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrPluginNotInstalled
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("check health: %d", resp.StatusCode)
+	}
+	var details healthCheckResponse
+	if err := json.NewDecoder(resp.Body).Decode(&details); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+	return &details, nil
+}
+
+// OpenAIEnabled returns true if the Grafana LLM App is configured to use OpenAI.
+func OpenAIEnabled(ctx context.Context, grafanaURL, grafanaAPIKey string) (bool, error) {
+	details, err := checkHealth(ctx, grafanaURL, grafanaAPIKey)
+	if err != nil {
+		return false, err
+	}
+	return details.OpenAIEnabled, nil
+}


### PR DESCRIPTION
Rather than adding a whole new client struct which would basically just wrap go-openai, this adds a simple function to return an `openai.ClientConfig` which will configure the go-openai client to talk to OpenAI via our app.

It also adds a simple `OpenAIEnabled` function which uses the new plugin health check endpoint.

This is an alternative to #59 