### PR TITLE
Add 'version' field to plugin health check

### DIFF
--- a/pkg/plugin/health.go
+++ b/pkg/plugin/health.go
@@ -5,11 +5,21 @@ import (
 	"encoding/json"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/build"
 )
 
 type healthCheckResponse struct {
-	OpenAIEnabled bool `json:"openAI"`
-	VectorEnabled bool `json:"vector"`
+	OpenAIEnabled bool   `json:"openAI"`
+	VectorEnabled bool   `json:"vector"`
+	Version       string `json:"version"`
+}
+
+func getVersion() string {
+	buildInfo, err := build.GetBuildInfo()
+	if err != nil {
+		return "unknown"
+	}
+	return buildInfo.Version
 }
 
 // CheckHealth handles health checks sent from Grafana to the plugin.
@@ -19,6 +29,7 @@ func (a *App) CheckHealth(_ context.Context, req *backend.CheckHealthRequest) (*
 	resp := healthCheckResponse{
 		OpenAIEnabled: settings.DecryptedSecureJSONData[openAIKey] != "",
 		VectorEnabled: a.vectorService != nil,
+		Version:       getVersion(),
 	}
 	body, err := json.Marshal(resp)
 	if err != nil {

--- a/pkg/plugin/health_test.go
+++ b/pkg/plugin/health_test.go
@@ -26,6 +26,7 @@ func TestCheckHealth(t *testing.T) {
 			expDetails: healthCheckResponse{
 				OpenAIEnabled: false,
 				VectorEnabled: false,
+				Version:       "unknown",
 			},
 		},
 		{
@@ -36,6 +37,7 @@ func TestCheckHealth(t *testing.T) {
 			expDetails: healthCheckResponse{
 				OpenAIEnabled: true,
 				VectorEnabled: false,
+				Version:       "unknown",
 			},
 		},
 		{
@@ -63,6 +65,7 @@ func TestCheckHealth(t *testing.T) {
 			expDetails: healthCheckResponse{
 				OpenAIEnabled: false,
 				VectorEnabled: true,
+				Version:       "unknown",
 			},
 		},
 		{
@@ -87,6 +90,7 @@ func TestCheckHealth(t *testing.T) {
 			expDetails: healthCheckResponse{
 				OpenAIEnabled: true,
 				VectorEnabled: true,
+				Version:       "unknown",
 			},
 		},
 	} {


### PR DESCRIPTION
This can be used to make @grafana/experimental backwards-compatible
with older plugin versions.

See https://github.com/grafana/grafana-experimental/pull/82 for a
motivating example.
