### PR TITLE
Add release instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ const MyComponent = (): JSX.Element => {
 
 ## Release process
 - Bump version in package.json (e.g., 0.2.0 to 0.2.1)
-- Add notes to changelog describing changes since last r elease
+- Add notes to changelog describing changes since last release
 - Merge PR for a branch containing those changes into main
 - Go to drone [here](https://drone.grafana.net/grafana/grafana-llm-app) and identify the build corresponding to the merge into main
 - Promote to target 'publish'

--- a/README.md
+++ b/README.md
@@ -199,3 +199,10 @@ const MyComponent = (): JSX.Element => {
 
    npm run lint:fix
    ```
+
+## Release process
+- Bump version in package.json (e.g., 0.2.0 to 0.2.1)
+- Add notes to changelog describing changes since last r elease
+- Merge PR for a branch containing those changes into main
+- Go to drone [here](https://drone.grafana.net/grafana/grafana-llm-app) and identify the build corresponding to the merge into main
+- Promote to target 'publish'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "llm",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",
@@ -36,7 +36,7 @@
         "@types/node": "^18.15.11",
         "@types/react-router-dom": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
-        "cspell": "6.13.3",
+        "cspell": "^6.13.3",
         "css-loader": "^6.7.3",
         "eslint-webpack-plugin": "^4.0.1",
         "fork-ts-checker-webpack-plugin": "^8.0.0",


### PR DESCRIPTION
Does what it says on the tin. Probably not very useful to anyone who isn't a maintainer. If the readme gets much longer it would make sense to split it out, I think.