### PR TITLE
Improve health check to return more granular details

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,8 @@ services:
       args:
         grafana_version: ${GRAFANA_VERSION:-10.1.0}
     environment:
+      AZURE_OPENAI_API_KEY: $AZURE_OPENAI_API_KEY
+      GF_LOG_LEVEL: debug
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID
       OPENAI_API_KEY: $OPENAI_API_KEY
     ports:

--- a/pkg/plugin/app.go
+++ b/pkg/plugin/app.go
@@ -27,6 +27,9 @@ type App struct {
 	backend.CallResourceHandler
 
 	vectorService vector.Service
+
+	healthCheckClient healthCheckClient
+	settings          Settings
 }
 
 // NewApp creates a new example *App instance.
@@ -35,21 +38,21 @@ func NewApp(ctx context.Context, appSettings backend.AppInstanceSettings) (insta
 	var app App
 
 	log.DefaultLogger.Debug("Loading settings")
-	settings := loadSettings(appSettings)
+	app.settings = loadSettings(appSettings)
 
 	// Use a httpadapter (provided by the SDK) for resource calls. This allows us
 	// to use a *http.ServeMux for resource calls, so we can map multiple routes
 	// to CallResource without having to implement extra logic.
 	mux := http.NewServeMux()
-	app.registerRoutes(mux, settings)
+	app.registerRoutes(mux, app.settings)
 	app.CallResourceHandler = httpadapter.New(mux)
 
 	var err error
 
-	if settings.Vector.Enabled {
+	if app.settings.Vector.Enabled {
 		log.DefaultLogger.Debug("Creating vector service")
 		app.vectorService, err = vector.NewService(
-			settings.Vector,
+			app.settings.Vector,
 			appSettings.DecryptedSecureJSONData,
 		)
 		if err != nil {
@@ -57,6 +60,8 @@ func NewApp(ctx context.Context, appSettings backend.AppInstanceSettings) (insta
 			return nil, err
 		}
 	}
+
+	app.healthCheckClient = &http.Client{}
 
 	return &app, nil
 }

--- a/pkg/plugin/app.go
+++ b/pkg/plugin/app.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"net/http"
+	"sync"
 
 	"github.com/grafana/grafana-llm-app/pkg/plugin/vector"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -29,6 +30,8 @@ type App struct {
 	vectorService vector.Service
 
 	healthCheckClient healthCheckClient
+	healthCheckMutex  sync.Mutex
+	healthCheckResult *backend.CheckHealthResult
 	settings          Settings
 }
 
@@ -62,6 +65,7 @@ func NewApp(ctx context.Context, appSettings backend.AppInstanceSettings) (insta
 	}
 
 	app.healthCheckClient = &http.Client{}
+	app.healthCheckMutex = sync.Mutex{}
 
 	return &app, nil
 }

--- a/pkg/plugin/health.go
+++ b/pkg/plugin/health.go
@@ -3,15 +3,44 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/build"
 )
 
-type healthCheckResponse struct {
-	OpenAIEnabled bool   `json:"openAI"`
-	VectorEnabled bool   `json:"vector"`
-	Version       string `json:"version"`
+var openAIModels = []string{"gpt-3.5-turbo", "gpt-4"}
+var vectorCollections = []string{"grafana.core.dashboards"}
+
+type healthCheckClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type openAIModelHealth struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+type openAIHealthDetails struct {
+	Configured bool                         `json:"configured"`
+	OK         bool                         `json:"ok"`
+	Error      string                       `json:"error,omitempty"`
+	Models     map[string]openAIModelHealth `json:"models"`
+}
+
+type vectorHealthDetails struct {
+	Enabled bool   `json:"enabled"`
+	OK      bool   `json:"ok"`
+	Error   string `json:"error,omitempty"`
+}
+
+type healthCheckDetails struct {
+	OpenAI  openAIHealthDetails `json:"openAI"`
+	Vector  vectorHealthDetails `json:"vector"`
+	Version string              `json:"version"`
 }
 
 func getVersion() string {
@@ -22,20 +51,117 @@ func getVersion() string {
 	return buildInfo.Version
 }
 
-// CheckHealth handles health checks sent from Grafana to the plugin.
-// It returns whether each feature is enabled based on the plugin settings.
-func (a *App) CheckHealth(_ context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	settings := req.PluginContext.AppInstanceSettings
-	resp := healthCheckResponse{
-		OpenAIEnabled: settings.DecryptedSecureJSONData[openAIKey] != "",
-		VectorEnabled: a.vectorService != nil,
-		Version:       getVersion(),
+func (a *App) testOpenAIModel(ctx context.Context, url *url.URL, model string) error {
+	body := map[string]interface{}{
+		"model": model,
+		"messages": []map[string]interface{}{
+			{
+				"role":    "user",
+				"content": "Hello",
+			},
+		},
 	}
-	body, err := json.Marshal(resp)
+	req, err := a.newOpenAIChatCompletionsRequest(ctx, url, body)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	resp, err := a.healthCheckClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("make request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		}
+		return fmt.Errorf("unexpected status code: %d: %s", resp.StatusCode, respBody)
+	}
+	return nil
+}
+
+func (a *App) openAIHealth(ctx context.Context) (openAIHealthDetails, error) {
+	d := openAIHealthDetails{
+		OK:         true,
+		Configured: a.settings.OpenAI.apiKey != "",
+		Models:     map[string]openAIModelHealth{},
+	}
+	u, err := url.Parse(a.settings.OpenAI.URL)
+	if err != nil {
+		return d, fmt.Errorf("Unable to parse OpenAI URL: %w", err)
+	}
+
+	for _, model := range openAIModels {
+		health := openAIModelHealth{OK: false, Error: "OpenAI not configured"}
+		if d.Configured {
+			health.OK = true
+			health.Error = ""
+			err := a.testOpenAIModel(ctx, u, model)
+			if err != nil {
+				health.OK = false
+				health.Error = err.Error()
+			}
+		}
+		d.Models[model] = health
+	}
+	anyOK := false
+	for _, v := range d.Models {
+		if v.OK {
+			anyOK = true
+			break
+		}
+	}
+	if !anyOK {
+		d.OK = false
+		d.Error = "No models are working"
+	}
+	return d, nil
+}
+
+func (a *App) testVectorService(ctx context.Context) error {
+	if a.vectorService == nil {
+		return fmt.Errorf("vector service not configured")
+	}
+	_, err := a.vectorService.Search(ctx, vectorCollections[0], "test", 1)
+	return err
+}
+
+func (a *App) vectorHealth(ctx context.Context) vectorHealthDetails {
+	d := vectorHealthDetails{
+		Enabled: a.settings.Vector.Enabled,
+		OK:      true,
+	}
+	if !d.Enabled {
+		d.OK = false
+		return d
+	}
+	err := a.testVectorService(ctx)
+	if err != nil {
+		d.OK = false
+		d.Error = err.Error()
+	}
+	return d
+}
+
+// CheckHealth handles health checks sent from Grafana to the plugin.
+// It returns whether each feature is working based on the plugin settings.
+func (a *App) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	openAI, err := a.openAIHealth(ctx)
+	if err != nil {
+		openAI.OK = false
+		openAI.Error = err.Error()
+	}
+	vector := a.vectorHealth(ctx)
+	details := healthCheckDetails{
+		OpenAI:  openAI,
+		Vector:  vector,
+		Version: getVersion(),
+	}
+	body, err := json.Marshal(details)
 	if err != nil {
 		return &backend.CheckHealthResult{
 			Status:  backend.HealthStatusError,
-			Message: "failed to marshal response",
+			Message: "failed to marshal details",
 		}, nil
 	}
 	return &backend.CheckHealthResult{

--- a/pkg/plugin/openai.go
+++ b/pkg/plugin/openai.go
@@ -1,0 +1,62 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+func (a *App) newAuthenticatedOpenAIRequest(ctx context.Context, method string, url url.URL, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	switch a.settings.OpenAI.Provider {
+	case openAIProviderOpenAI:
+		req.Header.Set("Authorization", "Bearer "+a.settings.OpenAI.apiKey)
+		req.Header.Set("OpenAI-Organization", a.settings.OpenAI.OrganizationID)
+	case openAIProviderAzure:
+		req.Header.Set("api-key", a.settings.OpenAI.apiKey)
+	}
+	return req, nil
+}
+
+func (a *App) newOpenAIChatCompletionsRequest(ctx context.Context, openAIURL *url.URL, body map[string]interface{}) (*http.Request, error) {
+	url := openAIURL
+	switch a.settings.OpenAI.Provider {
+	case openAIProviderOpenAI:
+		url.Path = "/v1/chat/completions"
+
+	case openAIProviderAzure:
+		deployment := ""
+		for _, v := range a.settings.OpenAI.AzureMapping {
+			if val, ok := body["model"].(string); ok && val == v[0] {
+				deployment = v[1]
+				break
+			}
+		}
+		if deployment == "" {
+			return nil, fmt.Errorf("no deployment found for model: %s", body["model"])
+		}
+		delete(body, "model")
+		url.Path = fmt.Sprintf("/openai/deployments/%s/chat/completions", deployment)
+		url.RawQuery = "api-version=2023-03-15-preview"
+
+	default:
+		return nil, fmt.Errorf("Unknown OpenAI provider: %s", a.settings.OpenAI.Provider)
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request body: %w", err)
+	}
+	req, err := a.newAuthenticatedOpenAIRequest(ctx, http.MethodPost, *url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -40,6 +40,13 @@ func loadSettings(appSettings backend.AppInstanceSettings) Settings {
 	}
 	_ = json.Unmarshal(appSettings.JSONData, &settings)
 
+	// We need to handle the case where the user has customized the URL,
+	// then reverted that customization so that the JSON data includes
+	// an empty string.
+	if settings.OpenAI.URL == "" {
+		settings.OpenAI.URL = "https://api.openai.com"
+	}
+
 	switch settings.OpenAI.Provider {
 	case openAIProviderOpenAI:
 	case openAIProviderAzure:

--- a/pkg/plugin/stream_test.go
+++ b/pkg/plugin/stream_test.go
@@ -86,7 +86,7 @@ func TestRunStream(t *testing.T) {
 			server := newMockOpenAIStreamServer(t, tc.statusCode, finish)
 
 			// Initialize app
-			settings := Settings{OpenAI: OpenAISettings{URL: server.server.URL}}
+			settings := Settings{OpenAI: OpenAISettings{URL: server.server.URL, Provider: openAIProviderOpenAI}}
 			jsonData, err := json.Marshal(settings)
 			if err != nil {
 				t.Fatalf("json marshal: %s", err)

--- a/provisioning/plugins/grafana-llm-app.yaml
+++ b/provisioning/plugins/grafana-llm-app.yaml
@@ -12,9 +12,12 @@ apps:
           type: qdrant
           qdrant:
             address: qdrant:6334
-      azureopenai:
-        resource: grafana-machine-learning-dev
+      # openAI:
+        # provider: azure
+        # url: https://<resource>.openai.azure.com
+        # azureModelMapping:
+        #   - ["gpt-3.5-turbo", "gpt-35-turbo"]
 
     secureJsonData:
       openAIKey: $OPENAI_API_KEY
-      azureOpenAIKey: $AZURE_OPENAI_API_KEY
+      # openAIKey: $AZURE_OPENAI_API_KEY

--- a/src/components/AppConfig/AppConfig.test.tsx
+++ b/src/components/AppConfig/AppConfig.test.tsx
@@ -19,6 +19,7 @@ describe('Components/AppConfig', () => {
           enabled: true,
           jsonData: {
             vector: {
+              enabled: true,
               store: {
                 type: 'qdrant',
               }

--- a/src/components/AppConfig/AppConfig.test.tsx
+++ b/src/components/AppConfig/AppConfig.test.tsx
@@ -46,6 +46,6 @@ describe('Components/AppConfig', () => {
     expect(screen.queryByTestId(testIds.appConfig.qdrantAddress)).toBeInTheDocument();
     // Don't expect to see the Grafana vector API field when type is qdrant
     expect(screen.queryByTestId(testIds.appConfig.grafanaVectorApiUrl)).toBeNull();
-    expect(screen.queryByRole('button', { name: /save settings/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /save & test/i })).toBeInTheDocument();
   });
 });

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -76,6 +76,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
         }}
       />
 
+      {healthCheck && <ShowHealthCheckResult {...healthCheck} />}
       <div className={s.marginTop}>
         <Button
           type="submit"
@@ -108,8 +109,6 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
         </Button>
         {isUpdating && <Spinner />}
       </div>
-
-      {healthCheck && <ShowHealthCheckResult {...healthCheck} />}
     </div>
   );
 };

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -40,7 +40,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
   // Whether each secret is already configured in the plugin backend.
   const [configuredSecrets, setConfiguredSecrets] = useState<SecretsSet>(initialSecrets(secureJsonFields ?? {}));
   // Whether any settings have been updated.
-  const [updated, setUpdated] = useState(true);
+  const [updated, setUpdated] = useState(false);
 
   const [isUpdating, setIsUpdating] = useState(false);
   const [healthCheck, setHealthCheck] = useState<HealthCheckResult | undefined>(undefined);

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -4,7 +4,7 @@ import { lastValueFrom } from 'rxjs';
 import { css } from '@emotion/css';
 import { AppPluginMeta, GrafanaTheme2, KeyValue, PluginConfigPageProps, PluginMeta } from '@grafana/data';
 import { FetchResponse, getBackendSrv, HealthCheckResult } from '@grafana/runtime';
-import { Button, Spinner, useStyles2 } from '@grafana/ui';
+import { Button, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 
 import { testIds } from '../testIds';
 import { OpenAIConfig, OpenAISettings } from './OpenAI';
@@ -76,7 +76,9 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
         }}
       />
 
-      {healthCheck && <ShowHealthCheckResult {...healthCheck} />}
+      {isUpdating ? <LoadingPlaceholder text="Running health check..." /> : healthCheck && (
+        <ShowHealthCheckResult {...healthCheck} />
+      )}
       <div className={s.marginTop}>
         <Button
           type="submit"
@@ -103,11 +105,10 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
             setIsUpdating(false);
             setHealthCheck(result.data);
           }}
-          disabled={!updated}
+          disabled={!updated || isUpdating}
         >
           Save &amp; test
         </Button>
-        {isUpdating && <Spinner />}
       </div>
     </div>
   );

--- a/src/components/AppConfig/HealthCheck.tsx
+++ b/src/components/AppConfig/HealthCheck.tsx
@@ -10,20 +10,34 @@ interface HealthCheckDetails {
 }
 
 interface OpenAIHealthDetails {
+  // Whether the minimum required OpenAI settings have been provided.
   configured: boolean;
+  // Whether we can call the OpenAI API with the provided settings.
   ok: boolean;
+  // If set, the error returned when trying to call the OpenAI API.
+  // Will be undefined if ok is true.
   error?: string;
+  // A map of model names to their health details.
+  // The health check attempts to call the OpenAI API with each
+  // of a few models and records the result of each call here.
   models: Record<string, OpenAIModelHealthDetails>;
 }
 
 interface OpenAIModelHealthDetails {
+  // Whether we can use this model in calls to OpenAI.
   ok: boolean;
+  // If set, the error returned when trying to call the OpenAI API.
+  // Will be undefined if ok is true.
   error?: string;
 }
 
 interface VectorHealthDetails {
+  // Whether the vector service has been enabled.
   enabled: boolean;
+  // Whether we can use the vector service with the provided settings.
   ok: boolean;
+  // If set, the error returned when trying to call the vector service.
+  // Will be undefined if ok is true.
   error?: string;
 }
 

--- a/src/components/AppConfig/HealthCheck.tsx
+++ b/src/components/AppConfig/HealthCheck.tsx
@@ -73,33 +73,32 @@ export function ShowHealthCheckResult(props: HealthCheckResult) {
   if (!isHealthCheckDetails(props.details)) {
     return (
       <div className="gf-form-group p-t-2">
-        <Alert severity={severity} title={props.message}>
-        </Alert>
+        <Alert severity={severity} title={props.message} />
       </div>
     );
   }
 
   severity = getAlertSeverity(props.status ?? 'error', props.details);
-  const message = severity === 'success' ? 'Health check succeeded!' : props.message;
-
+  const showOpenAI = typeof props.details.openAI === 'boolean' || typeof props.details.openAI === 'object' && props.details.openAI.configured;
+  const showVector = typeof props.details.vector === 'boolean' || typeof props.details.vector === 'object' && props.details.vector.enabled;
   return (
     <VerticalGroup>
-      <Alert severity={severity} title={message}>
-        <ShowOpenAIHealth openAI={props.details.openAI} />
-        <ShowVectorHealth vector={props.details.vector} />
-      </Alert>
-    </VerticalGroup>
+      {showOpenAI && <ShowOpenAIHealth openAI={props.details.openAI} />}
+      {showVector && <ShowVectorHealth vector={props.details.vector} />}
+    </VerticalGroup >
   );
 }
 
 function ShowOpenAIHealth({ openAI }: { openAI: OpenAIHealthDetails | boolean }) {
   if (typeof openAI === 'boolean') {
-    return <div>OpenAI: {openAI ? 'Enabled' : 'Disabled'}</div>;
+    const severity = openAI ? 'success' : 'error';
+    const message = openAI ? 'OpenAI health check succeeded!' : 'OpenAI health check failed.'
+    return <Alert title={message} severity={severity} />;
   }
+  const message = openAI.ok ? 'OpenAI health check succeeded!' : 'OpenAI health check failed.'
+  const severity = openAI.ok ? 'success' : 'error';
   return (
-    <div>
-      <h5>OpenAI</h5>
-      <div>{openAI.ok ? 'OK' : `Error: ${openAI.error}`}</div>
+    <Alert severity={severity} title={message}>
       <b>Models</b>
       <div>
         {Object.entries(openAI.models).map(([model, details], i) => (
@@ -108,21 +107,21 @@ function ShowOpenAIHealth({ openAI }: { openAI: OpenAIHealthDetails | boolean })
           </li>
         ))}
       </div>
-    </div>
+    </Alert>
   )
 }
 
 function ShowVectorHealth({ vector }: { vector: VectorHealthDetails | boolean }) {
   if (typeof vector === 'boolean') {
-    return <div>Vector: {vector ? 'Enabled' : 'Disabled'}</div>;
+    const severity = vector ? 'success' : 'error';
+    const message = vector ? 'Vector service health check succeeded!' : 'Vector service health check failed.'
+    return <Alert title={message} severity={severity} />;
   }
+  const severity = vector.ok ? 'success' : 'error';
+  const message = vector.ok ? 'Vector service health check succeeded!' : 'Vector service health check failed.'
   return (
-    <div>
-      <h5>Vector service</h5>
-      <div>{vector.enabled ? 'Enabled' : 'Disabled'}</div>
-      {vector.enabled && (
-        <div>{vector.ok ? 'OK' : `Error: ${vector.error}`}</div>
-      )}
-    </div>
+    <Alert title={message} severity={severity}>
+      {vector.error && <div>Error: {vector.error}</div>}
+    </Alert>
   )
 }

--- a/src/components/AppConfig/HealthCheck.tsx
+++ b/src/components/AppConfig/HealthCheck.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { HealthCheckResult } from "@grafana/runtime";
-import { Alert, AlertVariant } from "@grafana/ui";
+import { Alert, AlertVariant, VerticalGroup } from "@grafana/ui";
 
 interface HealthCheckDetails {
   openAI: OpenAIHealthDetails | boolean;
@@ -83,12 +83,12 @@ export function ShowHealthCheckResult(props: HealthCheckResult) {
   const message = severity === 'success' ? 'Health check succeeded!' : props.message;
 
   return (
-    <div className="gf-form-group p-t-2">
+    <VerticalGroup>
       <Alert severity={severity} title={message}>
         <ShowOpenAIHealth openAI={props.details.openAI} />
         <ShowVectorHealth vector={props.details.vector} />
       </Alert>
-    </div>
+    </VerticalGroup>
   );
 }
 

--- a/src/components/AppConfig/HealthCheck.tsx
+++ b/src/components/AppConfig/HealthCheck.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+
+import { HealthCheckResult } from "@grafana/runtime";
+import { Alert, AlertVariant } from "@grafana/ui";
+
+interface HealthCheckDetails {
+  openAI: OpenAIHealthDetails | boolean;
+  vector: VectorHealthDetails | boolean;
+  version: string;
+}
+
+interface OpenAIHealthDetails {
+  configured: boolean;
+  ok: boolean;
+  error?: string;
+  models: Record<string, OpenAIModelHealthDetails>;
+}
+
+interface OpenAIModelHealthDetails {
+  ok: boolean;
+  error?: string;
+}
+
+interface VectorHealthDetails {
+  enabled: boolean;
+  ok: boolean;
+  error?: string;
+}
+
+const isHealthCheckDetails = (obj: unknown): obj is HealthCheckDetails => {
+  return typeof obj === 'object' && obj !== null && 'openAI' in obj && 'vector' in obj && 'version' in obj;
+}
+
+const alertVariants = new Set<AlertVariant>(['success', 'info', 'warning', 'error']);
+const isAlertVariant = (str: string): str is AlertVariant => alertVariants.has(str as AlertVariant);
+const getAlertVariant = (status: string): AlertVariant => {
+  if (status.toLowerCase() === 'ok') {
+    return 'success';
+  }
+  return isAlertVariant(status) ? status : 'info';
+};
+const getAlertSeverity = (status: string, details: HealthCheckDetails): AlertVariant => {
+  const severity = getAlertVariant(status);
+  if (severity !== 'success') {
+    return severity;
+  }
+  if (!isHealthCheckDetails(details)) {
+    return 'success';
+  }
+  if (typeof details.openAI === 'object' && typeof details.vector === 'object') {
+    const vectorOk = !details.vector.enabled || details.vector.ok;
+    return details.openAI.ok && vectorOk ? 'success' : 'warning';
+  }
+  return severity;
+}
+
+export function ShowHealthCheckResult(props: HealthCheckResult) {
+  let severity = getAlertVariant(props.status ?? 'error');
+  if (!isHealthCheckDetails(props.details)) {
+    return (
+      <div className="gf-form-group p-t-2">
+        <Alert severity={severity} title={props.message}>
+        </Alert>
+      </div>
+    );
+  }
+
+  severity = getAlertSeverity(props.status ?? 'error', props.details);
+  const message = severity === 'success' ? 'Health check succeeded!' : props.message;
+
+  return (
+    <div className="gf-form-group p-t-2">
+      <Alert severity={severity} title={message}>
+        <ShowOpenAIHealth openAI={props.details.openAI} />
+        <ShowVectorHealth vector={props.details.vector} />
+      </Alert>
+    </div>
+  );
+}
+
+function ShowOpenAIHealth({ openAI }: { openAI: OpenAIHealthDetails | boolean }) {
+  if (typeof openAI === 'boolean') {
+    return <div>OpenAI: {openAI ? 'Enabled' : 'Disabled'}</div>;
+  }
+  return (
+    <div>
+      <h5>OpenAI</h5>
+      <div>{openAI.ok ? 'OK' : `Error: ${openAI.error}`}</div>
+      <b>Models</b>
+      <table>
+        <thead>
+        </thead>
+        <tbody>
+          {Object.entries(openAI.models).map(([model, details], i) => (
+            <tr key={i}>
+              <td>{model}: </td>
+              <td>{details.ok ? 'OK' : `Error: ${details.error}`}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function ShowVectorHealth({ vector }: { vector: VectorHealthDetails | boolean }) {
+  if (typeof vector === 'boolean') {
+    return <div>Vector: {vector ? 'Enabled' : 'Disabled'}</div>;
+  }
+  return (
+    <div>
+      <h5>Vector service</h5>
+      <div>{vector.enabled ? 'Enabled' : 'Disabled'}</div>
+      {vector.enabled && (
+        <div>{vector.ok ? 'OK' : `Error: ${vector.error}`}</div>
+      )}
+    </div>
+  )
+}

--- a/src/components/AppConfig/HealthCheck.tsx
+++ b/src/components/AppConfig/HealthCheck.tsx
@@ -101,18 +101,13 @@ function ShowOpenAIHealth({ openAI }: { openAI: OpenAIHealthDetails | boolean })
       <h5>OpenAI</h5>
       <div>{openAI.ok ? 'OK' : `Error: ${openAI.error}`}</div>
       <b>Models</b>
-      <table>
-        <thead>
-        </thead>
-        <tbody>
-          {Object.entries(openAI.models).map(([model, details], i) => (
-            <tr key={i}>
-              <td>{model}: </td>
-              <td>{details.ok ? 'OK' : `Error: ${details.error}`}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div>
+        {Object.entries(openAI.models).map(([model, details], i) => (
+          <li key={i}>
+            {model}: {details.ok ? 'OK' : `Error: ${details.error}`}
+          </li>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/AppConfig/Vector.tsx
+++ b/src/components/AppConfig/Vector.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Field, FieldSet, Input, Select, Switch, useStyles2 } from "@grafana/ui";
+import { Checkbox, Field, FieldSet, Input, Select, useStyles2 } from "@grafana/ui";
 
 import { testIds } from "components/testIds";
 import { getStyles } from "./AppConfig";
@@ -50,7 +50,7 @@ export function VectorConfig({ settings, onChange }: Props<VectorSettings>) {
     <FieldSet label="Vector Settings">
 
       <Field label="Enabled" description="Enable vector database powered features.">
-        <Switch
+        <Checkbox
           name="enabled"
           data-testid={testIds.appConfig.vectorEnabled}
           defaultChecked={settings?.enabled}
@@ -141,7 +141,7 @@ function QdrantConfig({ settings, onChange }: Props<QdrantSettings>) {
         />
       </Field>
       <Field label="Secure" description="Whether to use a secure connection">
-        <Switch
+        <Checkbox
           name="secure"
           data-testid={testIds.appConfig.qdrantSecure}
           defaultChecked={settings?.secure}

--- a/src/components/AppConfig/Vector.tsx
+++ b/src/components/AppConfig/Vector.tsx
@@ -59,26 +59,30 @@ export function VectorConfig({ settings, onChange }: Props<VectorSettings>) {
         />
       </Field>
 
-      <Field label="Model" description="The model used by the embedder and for embeddings stored in the store">
-        <Input
-          width={60}
-          name="model"
-          data-testid={testIds.appConfig.model}
-          value={settings?.model}
-          placeholder={""}
-          onChange={e => onChange({ ...settings, model: e.currentTarget.value })}
-        />
-      </Field>
+      {settings?.enabled && (
+        <>
+          <Field label="Model" description="The model used by the embedder and for embeddings stored in the store">
+            <Input
+              width={60}
+              name="model"
+              data-testid={testIds.appConfig.model}
+              value={settings?.model}
+              placeholder={""}
+              onChange={e => onChange({ ...settings, model: e.currentTarget.value })}
+            />
+          </Field>
 
-      <EmbedderConfig
-        settings={settings?.embed}
-        onChange={embed => onChange({ ...settings, embed })}
-      />
+          <EmbedderConfig
+            settings={settings?.embed}
+            onChange={embed => onChange({ ...settings, embed })}
+          />
 
-      <StoreConfig
-        settings={settings?.store}
-        onChange={store => onChange({ ...settings, store })}
-      />
+          <StoreConfig
+            settings={settings?.store}
+            onChange={store => onChange({ ...settings, store })}
+          />
+        </>
+      )}
     </FieldSet>
   )
 }


### PR DESCRIPTION
The Dashboard AI team have requested that the plugin health check returns more details about whether the OpenAI functionality is configured, and whether that configuration is valid. This PR adds it, and similar functionality for the vector service.

It's backwards incompatible with past health checks unfortunately, but the llmclient package does include a change which should be compatible with both the current and previous version of the plugin.

We're definitely due a refactor of the way we handle OpenAI config and requests, but I think that will be part of #80.