### PR TITLE
Don't use checked and defaultChecked in qdrant secure settings

### DIFF
--- a/src/components/AppConfig/Vector.tsx
+++ b/src/components/AppConfig/Vector.tsx
@@ -53,7 +53,6 @@ export function VectorConfig({ settings, onChange }: Props<VectorSettings>) {
         <Checkbox
           name="enabled"
           data-testid={testIds.appConfig.vectorEnabled}
-          defaultChecked={settings?.enabled}
           checked={settings?.enabled}
           onChange={e => onChange({ ...settings, enabled: e.currentTarget.checked })}
         />
@@ -144,7 +143,6 @@ function QdrantConfig({ settings, onChange }: Props<QdrantSettings>) {
         <Checkbox
           name="secure"
           data-testid={testIds.appConfig.qdrantSecure}
-          defaultChecked={settings?.secure}
           checked={settings?.secure}
           onChange={e => onChange({ ...settings, secure: e.currentTarget.checked })}
         />


### PR DESCRIPTION
As flagged in a console message in a CI run
(https://drone.grafana.net/grafana/grafana-llm-app/275/1/4)
