### PR TITLE
Added auth logic for vectorapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add basic auth to VectorAPI 
+
 ## 0.4.0
 
 * Add 'Enabled' switch for vector services to configuration UI

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -44,6 +44,7 @@
     "testid",
     "unmarshalling",
     "Upsert",
-    "vectorapi"
+    "vectorapi",
+    "BAAI"
   ]
 }

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/grafana/grafana-llm-app/pkg/plugin/vector"
+	"github.com/grafana/grafana-llm-app/pkg/plugin/vector/embed"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
@@ -46,6 +47,10 @@ func loadSettings(appSettings backend.AppInstanceSettings) Settings {
 	if settings.OpenAI.URL == "" {
 		settings.OpenAI.URL = "https://api.openai.com"
 	}
+	if settings.Vector.Embed.Type == embed.EmbedderOpenAI {
+		settings.Vector.Embed.OpenAI.URL = settings.OpenAI.URL
+		settings.Vector.Embed.OpenAI.AuthType = "openai-key-auth"
+	}
 
 	switch settings.OpenAI.Provider {
 	case openAIProviderOpenAI:
@@ -57,5 +62,6 @@ func loadSettings(appSettings backend.AppInstanceSettings) Settings {
 	}
 
 	settings.OpenAI.apiKey = appSettings.DecryptedSecureJSONData[openAIKey]
+
 	return settings
 }

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -1,0 +1,97 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func TestEmbeddingSettingLogic(t *testing.T) {
+
+	// Set up and run test cases
+	for _, tc := range []struct {
+		name                   string
+		settings               backend.AppInstanceSettings
+		embeddingURL           string
+		embeddingAuthType      string
+		embeddingBasicAuthUser string
+	}{
+		{
+			name: "openai-embedder-option",
+			settings: backend.AppInstanceSettings{
+				JSONData: []byte(`{
+					"openAI": {
+						"url": "https://api.openai.com",
+						"provider": "openai"
+					},
+					"vector": {
+						"embed": {
+							"type": "openai"
+						}
+					}
+				}`),
+				DecryptedSecureJSONData: map[string]string{openAIKey: "abcd1234"},
+			},
+			embeddingURL:           "https://api.openai.com",
+			embeddingAuthType:      "openai-key-auth",
+			embeddingBasicAuthUser: "",
+		},
+		{
+			name: "grafana-vector-api-no-auth",
+			settings: backend.AppInstanceSettings{
+				JSONData: []byte(`{
+					"vector": {
+						"embed": {
+							"type": "grafana/vectorapi",
+							"openai": {
+								"url": "https://api.example.com",
+								"authType": "no-auth"
+							}
+						}
+					}
+				}`),
+			},
+			embeddingURL:           "https://api.example.com",
+			embeddingAuthType:      "no-auth",
+			embeddingBasicAuthUser: "",
+		},
+		{
+			name: "grafana-vector-api-basic-auth",
+			settings: backend.AppInstanceSettings{
+				JSONData: []byte(`{
+					"vector": {
+						"embed": {
+							"type": "grafana/vectorapi",
+							"openai": {
+								"url": "https://api.example.com",
+								"authType": "basic-auth",
+								"basicAuthUser": "test"
+							}
+						}
+					}
+				}`),
+			},
+			embeddingURL:           "https://api.example.com",
+			embeddingAuthType:      "basic-auth",
+			embeddingBasicAuthUser: "test",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := loadSettings(tc.settings)
+
+			// Assert that the settings are loaded correctly
+			if settings.Vector.Embed.OpenAI.URL != tc.embeddingURL {
+				t.Errorf("expected embedding URL to be %s, got %s", tc.embeddingURL, settings.Vector.Embed.OpenAI.URL)
+			}
+
+			if settings.Vector.Embed.OpenAI.AuthType != tc.embeddingAuthType {
+				t.Errorf("expected embedding auth type to be %s, got %s", tc.embeddingAuthType, settings.Vector.Embed.OpenAI.AuthType)
+			}
+
+			if settings.Vector.Embed.OpenAI.BasicAuthUser != tc.embeddingBasicAuthUser {
+				t.Errorf("expected embedding basic auth user to be %s, got %s", tc.embeddingBasicAuthUser, settings.Vector.Embed.OpenAI.BasicAuthUser)
+			}
+
+		})
+	}
+}

--- a/pkg/plugin/vector/embed/embedder.go
+++ b/pkg/plugin/vector/embed/embedder.go
@@ -27,5 +27,7 @@ type Settings struct {
 // NewEmbedder creates a new embedder.
 func NewEmbedder(s Settings, secrets map[string]string) (Embedder, error) {
 	log.DefaultLogger.Debug("Creating OpenAI embedder")
+	// Grafana Vector API embedder is OpenAI compatible so we can reuse the client
+	// The EmbedderType is used in settings.load_settings to duplicate the correct OpenAI settings
 	return newOpenAIEmbedder(s.OpenAI, secrets), nil
 }

--- a/pkg/plugin/vector/embed/embedder.go
+++ b/pkg/plugin/vector/embed/embedder.go
@@ -9,25 +9,23 @@ import (
 type EmbedderType string
 
 const (
-	EmbedderOpenAI EmbedderType = "openai"
+	EmbedderOpenAI           EmbedderType = "openai"
+	EmbedderGrafanaVectorAPI EmbedderType = "grafana/vectorapi"
 )
 
 type Embedder interface {
 	Embed(ctx context.Context, model string, text string) ([]float32, error)
+	Health(ctx context.Context, model string) error
 }
 
 type Settings struct {
-	Type string `json:"type"`
+	Type EmbedderType `json:"type"`
 
 	OpenAI openAISettings `json:"openai"`
 }
 
 // NewEmbedder creates a new embedder.
 func NewEmbedder(s Settings, secrets map[string]string) (Embedder, error) {
-	switch EmbedderType(s.Type) {
-	case EmbedderOpenAI:
-		log.DefaultLogger.Debug("Creating OpenAI embedder")
-		return newOpenAIEmbedder(s.OpenAI, secrets), nil
-	}
-	return nil, nil
+	log.DefaultLogger.Debug("Creating OpenAI embedder")
+	return newOpenAIEmbedder(s.OpenAI, secrets), nil
 }

--- a/pkg/plugin/vector/embed/openai.go
+++ b/pkg/plugin/vector/embed/openai.go
@@ -77,7 +77,6 @@ func (o *openAIClient) Embed(ctx context.Context, model string, payload string) 
 	req.Header.Set("Content-Type", "application/json")
 	o.setAuth(req)
 
-	log.DefaultLogger.Info("MMMMMMMMMMMaking request", "req", fmt.Sprintf("%+v", req))
 	resp, err := o.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("make request: %w", err)

--- a/pkg/plugin/vector/service.go
+++ b/pkg/plugin/vector/service.go
@@ -51,7 +51,6 @@ func NewService(s VectorSettings, secrets map[string]string) (Service, error) {
 		return nil, nil
 	}
 
-	log.DefaultLogger.Info("Vector service created", "model", fmt.Sprintf("EEEEEEEE%+v\nSSSSSSS%+v", em, st))
 	return &vectorService{
 		embedder: em,
 		store:    st,

--- a/pkg/plugin/vector/service.go
+++ b/pkg/plugin/vector/service.go
@@ -50,6 +50,8 @@ func NewService(s VectorSettings, secrets map[string]string) (Service, error) {
 		log.DefaultLogger.Warn("No vector store configured")
 		return nil, nil
 	}
+
+	log.DefaultLogger.Info("Vector service created", "model", fmt.Sprintf("EEEEEEEE%+v\nSSSSSSS%+v", em, st))
 	return &vectorService{
 		embedder: em,
 		store:    st,
@@ -88,7 +90,15 @@ func (v *vectorService) Search(ctx context.Context, collection string, query str
 }
 
 func (v *vectorService) Health(ctx context.Context) error {
-	return v.store.Health(ctx)
+	err := v.store.Health(ctx)
+	if err != nil {
+		return fmt.Errorf("vector store health: %w", err)
+	}
+	err = v.embedder.Health(ctx, v.model)
+	if err != nil {
+		return fmt.Errorf("embedder health: %w", err)
+	}
+	return nil
 }
 
 func (v vectorService) Cancel() {

--- a/pkg/plugin/vector/store/store.go
+++ b/pkg/plugin/vector/store/store.go
@@ -49,10 +49,6 @@ type AuthSettings struct {
 type Settings struct {
 	Type VectorStoreType `json:"type"`
 
-	AuthType VectorStoreAuthType `json:"authType"`
-
-	AuthSettings AuthSettings `json:"authSettings"`
-
 	GrafanaVectorAPI GrafanaVectorAPISettings `json:"grafanaVectorAPI"`
 
 	Qdrant qdrantSettings `json:"qdrant"`

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -18,6 +18,8 @@ export interface AppPluginSettings {
 
 export type Secrets = {
   openAIKey?: string;
+  vectorStoreBasicAuthPassword?: string;
+  vectorEmbedderBasicAuthPassword?: string;
 }
 
 export type SecretsSet = {
@@ -27,6 +29,8 @@ export type SecretsSet = {
 function initialSecrets(secureJsonFields: KeyValue<boolean>): SecretsSet {
   return {
     openAIKey: secureJsonFields.openAIKey ?? false,
+    vectorEmbedderBasicAuthPassword: secureJsonFields.vectorEmbedderBasicAuthPassword ?? false,
+    vectorStoreBasicAuthPassword: secureJsonFields.vectorStoreBasicAuthPassword ?? false,
   };
 }
 
@@ -69,9 +73,21 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
       />
 
       <VectorConfig
-        settings={settings.vector}
+        settings={settings}
+        secrets={newSecrets}
+        secretsSet={configuredSecrets}
         onChange={(vector) => {
           setSettings({ ...settings, vector });
+          setUpdated(true);
+        }}
+        onChangeSecrets={secrets => {
+          // Update the new secrets.
+          setNewSecrets(secrets);
+          // Mark each secret as not configured. This will cause it to be included
+          // in the request body when the user clicks "Save settings".
+          for (const key of Object.keys(secrets)) {
+            setConfiguredSecrets({ ...configuredSecrets, [key]: false });
+          }
           setUpdated(true);
         }}
       />
@@ -121,6 +137,8 @@ export const getStyles = (theme: GrafanaTheme2) => ({
   marginTop: css`
     margin-top: ${theme.spacing(3)};
   `,
+  inlineFieldWidth: 15,
+  inlineFieldInputWidth: 40,
 });
 
 export const updatePlugin = (pluginId: string, data: Partial<PluginMeta>) => {

--- a/src/components/AppConfig/AuthSettings/BasicAuth.tsx
+++ b/src/components/AppConfig/AuthSettings/BasicAuth.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { InlineField, Input, SecretInput, useStyles2 } from '@grafana/ui';
+
+import { testIds } from "components/testIds";
+import { Secrets, SecretsSet, getStyles } from "../AppConfig";
+
+import { AuthSettings } from '../Vector'
+
+
+export const BasicAuthConfig = ({ settings, secrets, secretsSet, onChange, onChangeSecrets, secretKey }: {
+  settings?: AuthSettings;
+  secrets: Secrets;
+  secretsSet: SecretsSet;
+  onChange: (settings: AuthSettings) => void;
+  onChangeSecrets: (secrets: Secrets) => void;
+  secretKey: "vectorEmbedderBasicAuthPassword" | "vectorStoreBasicAuthPassword";
+}) => {
+  const s = useStyles2(getStyles);
+
+  const onPasswordReset = () => {
+    onChangeSecrets({
+      ...secrets, [secretKey]: '',
+    });
+  };
+
+  const onPasswordChange = (event: React.SyntheticEvent<HTMLInputElement>) => {
+    onChangeSecrets({
+      ...secrets, [secretKey]: event.currentTarget.value,
+    });
+  };
+
+  return (
+    <>
+      <InlineField label="User" labelWidth={s.inlineFieldWidth}>
+        <Input
+          width={s.inlineFieldInputWidth}
+          placeholder="user"
+          data-testid={testIds.appConfig.basicAuthUsername}
+          value={settings?.basicAuthUser}
+          onChange={e => onChange({ ...settings, basicAuthUser: e.currentTarget.value })}
+        />
+      </InlineField>
+      <InlineField label="Password" labelWidth={s.inlineFieldWidth}>
+        <SecretInput
+          width={s.inlineFieldInputWidth}
+          placeholder="password"
+          data-testid={testIds.appConfig.basicAuthPassword}
+          value={secrets[secretKey]}
+          isConfigured={secretsSet[secretKey] ?? false}
+          onReset={onPasswordReset}
+          onChange={onPasswordChange}
+        />
+      </InlineField>
+    </>
+  );
+};

--- a/src/components/AppConfig/Vector.tsx
+++ b/src/components/AppConfig/Vector.tsx
@@ -71,7 +71,7 @@ export function VectorConfig({ settings, secrets, secretsSet, onChange, onChange
     ) {
       onChange({ ...settings.vector, model: VECTORAPI_DEFAULT_MODEL });
     }
-  }, [settings?.vector, settings?.vector?.embed?.type]);
+  }, [settings?.vector, settings?.vector?.embed?.type, onChange]);
 
   return (
     <FieldSet label="Vector Settings">

--- a/src/components/AppConfig/Vector.tsx
+++ b/src/components/AppConfig/Vector.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 
-import { Checkbox, Field, FieldSet, Input, Select, useStyles2 } from "@grafana/ui";
+import { Checkbox, Field, FieldSet, InlineField, Input, Select, useStyles2, Label } from "@grafana/ui";
 
 import { testIds } from "components/testIds";
-import { getStyles } from "./AppConfig";
+import { AppPluginSettings, Secrets, SecretsSet, getStyles } from "./AppConfig";
+
+import { BasicAuthConfig } from "./AuthSettings/BasicAuth";
+import { SelectableValue } from "@grafana/data";
 
 export interface VectorSettings {
   // Whether the vector service should be enabled.
@@ -16,12 +19,19 @@ export interface VectorSettings {
   store?: StoreSettings;
 };
 
-interface OpenAIEmbedderSettings {
+export interface AuthSettings {
   url?: string;
-};
+  authType?: string;
+  basicAuthUser?: string;
+}
+
+interface OpenAIEmbedderSettings extends AuthSettings {}
+
+interface GrafanaVectorAPISettings extends AuthSettings {}
+
 
 interface EmbedderSettings {
-  type?: string;
+  type?: EmbedderOptions;
   openai?: OpenAIEmbedderSettings;
 };
 
@@ -30,22 +40,25 @@ interface QdrantSettings {
   secure?: boolean;
 }
 
-interface GrafanaVectorAPISettings {
-  url?: string;
-}
-
 interface StoreSettings {
   type?: string;
   qdrant?: QdrantSettings;
   grafanaVectorAPI?: GrafanaVectorAPISettings;
 }
 
-interface Props<T> {
+export interface Props<T> {
   settings?: T;
   onChange: (settings: T) => void;
 }
 
-export function VectorConfig({ settings, onChange }: Props<VectorSettings>) {
+export function VectorConfig({ settings, secrets, secretsSet, onChange, onChangeSecrets }: {
+  settings?: AppPluginSettings;
+  secrets: Secrets;
+  secretsSet: SecretsSet;
+  onChange: (settings: VectorSettings) => void;
+  onChangeSecrets: (secrets: Secrets) => void;
+}) {
+  const modelValues = settings?.vector?.embed?.type === "openai" ? "text-embedding-ada-002" : settings?.vector?.embed?.type === "grafana/vectorapi" ? (settings?.vector?.model ?? "BAAI/bge-small-en-v1.5"): ""
   return (
     <FieldSet label="Vector Settings">
 
@@ -53,32 +66,38 @@ export function VectorConfig({ settings, onChange }: Props<VectorSettings>) {
         <Checkbox
           name="enabled"
           data-testid={testIds.appConfig.vectorEnabled}
-          checked={settings?.enabled}
+          value={settings?.vector?.enabled || false}
           onChange={e => onChange({ ...settings, enabled: e.currentTarget.checked })}
         />
       </Field>
-
-      {settings?.enabled && (
+  
+      {settings?.vector?.enabled && (
         <>
-          <Field label="Model" description="The model used by the embedder and for embeddings stored in the store">
+          <Field label="Model" description="The model used by the embedder and for embeddings stored in the store" disabled={settings.vector?.embed?.type === "openai" || settings.vector?.embed?.type === undefined}>
             <Input
               width={60}
               name="model"
               data-testid={testIds.appConfig.model}
-              value={settings?.model}
+              value={modelValues}
               placeholder={""}
               onChange={e => onChange({ ...settings, model: e.currentTarget.value })}
             />
           </Field>
 
           <EmbedderConfig
-            settings={settings?.embed}
-            onChange={embed => onChange({ ...settings, embed })}
+            settings={settings?.vector?.embed}
+            secrets={secrets}
+            secretsSet={secretsSet}
+            onChange={embed => onChange({ ...settings.vector, embed}) }
+            onChangeSecrets={onChangeSecrets}
           />
 
           <StoreConfig
-            settings={settings?.store}
-            onChange={store => onChange({ ...settings, store })}
+            settings={settings?.vector?.store}
+            secrets={secrets}
+            secretsSet={secretsSet}
+            onChange={store => onChange({ ...settings.vector, store })}
+            onChangeSecrets={onChangeSecrets}
           />
         </>
       )}
@@ -86,41 +105,75 @@ export function VectorConfig({ settings, onChange }: Props<VectorSettings>) {
   )
 }
 
-function OpenAIEmbedderConfig({ settings, onChange }: Props<OpenAIEmbedderSettings>) {
-  const s = useStyles2(getStyles);
-  return (
-    <Field label="OpenAI API URL" description="" className={s.marginTop}>
-      <Input
-        width={60}
-        name="url"
-        data-testid={testIds.appConfig.openAIUrl}
-        value={settings?.url}
-        placeholder={"https://api.openai.com"}
-        onChange={e => onChange({ ...settings, url: e.currentTarget.value })}
-      />
-    </Field>
-  );
-}
+type EmbedderOptions = 'openai' | 'grafana/vectorapi';
 
-function EmbedderConfig({ settings, onChange }: Props<EmbedderSettings>) {
+
+export function EmbedderConfig({ settings, secrets, secretsSet, onChange, onChangeSecrets }: {
+  settings?: EmbedderSettings;
+  secrets: Secrets;
+  secretsSet: SecretsSet;
+  onChange: (settings: EmbedderSettings) => void;
+  onChangeSecrets: (secrets: Secrets) => void;
+}) {
+  const s = useStyles2(getStyles);
+
   return (
     <>
       <h4>Embedder</h4>
-      <Field label="Embedder Type" description="The type of embedder">
-        <Select
-          options={[
-            { label: "OpenAI", value: "openai" },
-          ]}
-          value={settings?.type}
-          onChange={e => e.value !== undefined && onChange({ ...settings, type: e.value })}
-          width={60}
-        />
+      <Field label="Embedder Provider" description="Select the embedder API to use">
+        <>
+          <Select
+            options={[
+              { label: "OpenAI API", value: "openai" },
+              { label: "Grafana Vector API", value: "grafana/vectorapi" },
+            ] as Array<SelectableValue<EmbedderOptions>>}
+            placeholder="Select Embedder Provider"
+            value={settings?.type}
+            width={60}
+            onChange={e => {
+              onChange({...settings,  type: e.value});
+            }}
+          />
+          {settings?.type === "openai" && (
+            <Label> Using configured OpenAI as embedder provider </Label>
+          )}
+        </>
       </Field>
-      {settings?.type === "openai" && (
-        <OpenAIEmbedderConfig
-          settings={settings.openai}
-          onChange={openai => onChange({ ...settings, openai })}
-        />
+
+      {settings?.type === "grafana/vectorapi" && (
+        <>
+          <Field label="Auth Type">
+            <Select
+              options={[
+                { label: "No Auth", value: "no-auth" },
+                { label: "Basic Auth", value: "basic-auth" },
+              ]}
+              value={settings?.openai?.authType ?? "no-auth"}
+              onChange={e => e.value !== undefined && onChange({ ...settings, openai: { ...settings.openai, authType: e.value} })}
+              width={60}
+            />
+          </Field>
+          <InlineField label="URL" tooltip="Address of the Grafana Vector API" labelWidth={s.inlineFieldWidth}>
+            <Input
+              name="url"
+              value={settings?.openai?.url}
+              width={s.inlineFieldInputWidth}
+              data-testid={testIds.appConfig.grafanaVectorApiUrl}
+              placeholder={"http://vectorapi:8889"}
+              onChange={e => onChange({ ...settings, openai: { ...settings.openai, url: e.currentTarget.value }})}
+            />
+          </InlineField>
+          {settings?.openai?.authType === "basic-auth" && (
+            <BasicAuthConfig
+              settings={settings.openai}
+              secrets={secrets}
+              secretsSet={secretsSet}
+              onChange={authSettings => onChange({ ...settings, openai: authSettings })} 
+              onChangeSecrets={onChangeSecrets}
+              secretKey="vectorEmbedderBasicAuthPassword"
+            />
+          )}
+        </>
       )}
     </>
   )
@@ -152,21 +205,30 @@ function QdrantConfig({ settings, onChange }: Props<QdrantSettings>) {
 }
 
 function GrafanaVectorAPIConfig({ settings, onChange }: Props<GrafanaVectorAPISettings>) {
+  const s = useStyles2(getStyles);
   return (
-    <Field label="URL" description="URL of the Grafana Vector API">
-      <Input
-        width={60}
-        name="url"
-        data-testid={testIds.appConfig.grafanaVectorApiUrl}
-        value={settings?.url}
-        placeholder={"https://vectorapi.grafana.com"}
-        onChange={e => onChange({ ...settings, url: e.currentTarget.value })}
-      />
-    </Field>
+    <>
+      <InlineField label="URL" tooltip="Address of the Grafana Vector API" labelWidth={s.inlineFieldWidth}>
+        <Input
+          name="url"
+          value={settings?.url}
+          width={s.inlineFieldInputWidth}
+          data-testid={testIds.appConfig.grafanaVectorApiUrl}
+          placeholder={"http://vectorapi:8889"}
+          onChange={e => onChange({ ...settings, url: e.currentTarget.value })}
+        />
+      </InlineField>
+    </>
   );
 }
 
-function StoreConfig({ settings, onChange }: Props<StoreSettings>) {
+function StoreConfig({ settings, secrets, secretsSet, onChange, onChangeSecrets }: {
+  settings?: StoreSettings;
+  secrets: Secrets;
+  secretsSet: SecretsSet;
+  onChange: (settings: StoreSettings) => void;
+  onChangeSecrets: (secrets: Secrets) => void;
+}) {
   return (
     <>
       <h4>Store</h4>
@@ -177,7 +239,7 @@ function StoreConfig({ settings, onChange }: Props<StoreSettings>) {
             { label: "Grafana Vector API", value: "grafana/vectorapi" },
           ]}
           value={settings?.type}
-          onChange={e => e.value !== undefined && onChange({ ...settings, type: e.value })}
+          onChange={e => e.value !== undefined && onChange({ ...settings, type: e.value, qdrant: undefined, grafanaVectorAPI: undefined })}
           width={60}
         />
       </Field>
@@ -188,12 +250,34 @@ function StoreConfig({ settings, onChange }: Props<StoreSettings>) {
         />
       )}
       {settings?.type === "grafana/vectorapi" && (
-        <GrafanaVectorAPIConfig
+        <>
+          <Field label="Auth Type">
+            <Select
+              options={[
+                { label: "No Auth", value: "no-auth" },
+                { label: "Basic Auth", value: "basic-auth" },
+              ]}
+              value={settings?.grafanaVectorAPI?.authType ?? "no-auth"}
+              onChange={e => e.value !== undefined && onChange({ ...settings, grafanaVectorAPI: { ...settings.grafanaVectorAPI, authType:e.value }})}
+              width={60}
+            />
+          </Field>
+          <GrafanaVectorAPIConfig
+            settings={settings.grafanaVectorAPI}
+            onChange={grafanaVectorAPI => onChange({ ...settings, grafanaVectorAPI })}
+          />
+        </>
+      )}
+      {settings?.type === "grafana/vectorapi" && settings?.grafanaVectorAPI?.authType === "basic-auth" && (
+        <BasicAuthConfig
           settings={settings.grafanaVectorAPI}
-          onChange={grafanaVectorAPI => onChange({ ...settings, grafanaVectorAPI })}
+          secrets={secrets}
+          secretsSet={secretsSet}
+          onChange={authSettings => onChange({ ...settings, grafanaVectorAPI: authSettings })} 
+          onChangeSecrets={onChangeSecrets}
+          secretKey="vectorStoreBasicAuthPassword"
         />
       )}
-
     </>
   )
 }

--- a/src/components/AppConfig/Vector.tsx
+++ b/src/components/AppConfig/Vector.tsx
@@ -80,7 +80,7 @@ export function VectorConfig({ settings, secrets, secretsSet, onChange, onChange
               data-testid={testIds.appConfig.model}
               value={modelValues}
               placeholder={""}
-              onChange={e => onChange({ ...settings, model: e.currentTarget.value })}
+              onChange={e => onChange({ ...settings.vector, model: e.currentTarget.value })}
             />
           </Field>
 

--- a/src/components/AppConfig/Vector.tsx
+++ b/src/components/AppConfig/Vector.tsx
@@ -51,6 +51,9 @@ export interface Props<T> {
   onChange: (settings: T) => void;
 }
 
+const OPENAI_DEFAULT_MODEL = 'text-embedding-ada-002';
+const VECTORAPI_DEFAULT_MODEL = 'BAAI/bge-small-en-v1.5';
+
 export function VectorConfig({ settings, secrets, secretsSet, onChange, onChangeSecrets }: {
   settings?: AppPluginSettings;
   secrets: Secrets;
@@ -58,7 +61,18 @@ export function VectorConfig({ settings, secrets, secretsSet, onChange, onChange
   onChange: (settings: VectorSettings) => void;
   onChangeSecrets: (secrets: Secrets) => void;
 }) {
-  const modelValues = settings?.vector?.embed?.type === "openai" ? "text-embedding-ada-002" : settings?.vector?.embed?.type === "grafana/vectorapi" ? (settings?.vector?.model ?? "BAAI/bge-small-en-v1.5"): ""
+  // update the model value if the embedder type changes
+  React.useEffect(() => {
+    if (settings?.vector?.embed?.type === 'openai' && settings?.vector?.model !== OPENAI_DEFAULT_MODEL) {
+      onChange({ ...settings.vector, model: OPENAI_DEFAULT_MODEL });
+    } else if (
+      settings?.vector?.embed?.type === 'grafana/vectorapi' &&
+      (settings?.vector?.model === undefined || settings?.vector?.model === OPENAI_DEFAULT_MODEL)
+    ) {
+      onChange({ ...settings.vector, model: VECTORAPI_DEFAULT_MODEL });
+    }
+  }, [settings?.vector, settings?.vector?.embed?.type]);
+
   return (
     <FieldSet label="Vector Settings">
 
@@ -78,9 +92,9 @@ export function VectorConfig({ settings, secrets, secretsSet, onChange, onChange
               width={60}
               name="model"
               data-testid={testIds.appConfig.model}
-              value={modelValues}
-              placeholder={""}
-              onChange={e => onChange({ ...settings.vector, model: e.currentTarget.value })}
+              value={settings?.vector?.model}
+              placeholder={settings?.vector?.model}
+              onChange={(e) => onChange({ ...settings.vector, model: e.currentTarget.value })}
             />
           </Field>
 

--- a/src/components/testIds.ts
+++ b/src/components/testIds.ts
@@ -11,6 +11,8 @@ export const testIds = {
     grafanaVectorApiUrl: 'data-testid ac-grafana-vector-api-url',
     model: 'data-testid ac-vector-model',
     submit: 'data-testid ac-submit-form',
+    basicAuthUsername: "data-testid ac-basic-auth-username",
+    basicAuthPassword: "data-testid ac-basic-auth-password",
   },
   models: {
     container: 'data-testid models-container',


### PR DESCRIPTION
- added basic auth for Embedder and Store settings
- Added a Grafana Vector API Embedder option
- updated healthcheck to include Vector Embedder endpoint

## Testing instructions
1. Setup Grafana with plugin installed
2. Configure OpenAI Settings
3. Configure Grafana Vector API under Embedding settings
4. Configure Grafana Vector API under Store settings
5. Save & test, and both OpenAI and Vector checks should pass

Note: currently Azure OpenAI is not yet supported as Embedder option
