### PR TITLE
fix(llmclient): always trim trailing slash from Grafana URL

### DIFF
--- a/llmclient/llmclient.go
+++ b/llmclient/llmclient.go
@@ -50,7 +50,8 @@ func NewOpenAI(grafanaURL, grafanaAPIKey string) OpenAI {
 // NewOpenAIWithClient creates a new OpenAI client talking to the Grafana LLM app installed
 // on the given Grafana instance, using the given HTTP client.
 func NewOpenAIWithClient(grafanaURL, grafanaAPIKey string, httpClient *http.Client) OpenAI {
-	url := strings.TrimRight(grafanaURL, "/") + appResourcesPrefix + "/openai/v1"
+	grafanaURL = strings.TrimRight(grafanaURL, "/")
+	url := grafanaURL + appResourcesPrefix + "/openai/v1"
 	cfg := openai.DefaultConfig(grafanaAPIKey)
 	cfg.BaseURL = url
 	cfg.HTTPClient = httpClient


### PR DESCRIPTION
Previously we trimmed the trailing slash from the Grafana URL before
using it in the underlying openai.Client, but _not_ before we used it
for health checks. This commit changes that so that we store the trimmed
URL, instead.
