### PR TITLE
Only cache healthy healthcheck results

### DIFF
--- a/pkg/plugin/app.go
+++ b/pkg/plugin/app.go
@@ -31,7 +31,8 @@ type App struct {
 
 	healthCheckClient healthCheckClient
 	healthCheckMutex  sync.Mutex
-	healthCheckResult *backend.CheckHealthResult
+	healthOpenAI      *openAIHealthDetails
+	healthVector      *vectorHealthDetails
 	settings          Settings
 }
 


### PR DESCRIPTION
Right now we cache results even if they come back unhealthy. This means that if OpenAI is down when a grafana instance restarts and is first queried the llm plugin will not be useful for the lifecycle of the instance. Instead, only cache if the results come back healthy.

It also breaks the cache into two parts so we can separately cache for a healthy OpenAI configuration vs VectorAPI configuration.