### PR TITLE
Update frontend development instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ The `.subscribe` method can take [a few different forms](https://github.com/Reac
 1. Install dependencies
 
    ```bash
-   npm run install
+   npm install
    ```
 
 2. Build plugin in development mode and run in watch mode


### PR DESCRIPTION
Running `npm run install` errors with:

```
$ npm run install
npm ERR! Missing script: "install"
npm ERR! 
npm ERR! Did you mean this?
npm ERR!     npm uninstall # Remove a package
npm ERR! 
npm ERR! To see a list of scripts, run:
npm ERR!   npm run
```

I think what was meant is `npm install`