### PR TITLE
feat: add Qdrant API key field to qdrant settings

### DIFF
--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -18,6 +18,7 @@ export interface AppPluginSettings {
 
 export type Secrets = {
   openAIKey?: string;
+  qdrantApiKey?: string;
   vectorStoreBasicAuthPassword?: string;
   vectorEmbedderBasicAuthPassword?: string;
 };
@@ -31,6 +32,7 @@ function initialSecrets(secureJsonFields: KeyValue<boolean>): SecretsSet {
     openAIKey: secureJsonFields.openAIKey ?? false,
     vectorEmbedderBasicAuthPassword: secureJsonFields.vectorEmbedderBasicAuthPassword ?? false,
     vectorStoreBasicAuthPassword: secureJsonFields.vectorStoreBasicAuthPassword ?? false,
+    qdrantApiKey: secureJsonFields.qdrantApiKey ?? false,
   };
 }
 

--- a/src/components/AppConfig/Vector.tsx
+++ b/src/components/AppConfig/Vector.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Checkbox, Field, FieldSet, InlineField, Input, Select, useStyles2, Label } from '@grafana/ui';
+import { Checkbox, Field, FieldSet, InlineField, Input, Select, useStyles2, Label, SecretInput } from '@grafana/ui';
 
 import { testIds } from 'components/testIds';
 import { Secrets, SecretsSet, getStyles } from './AppConfig';
@@ -200,7 +200,7 @@ export function EmbedderConfig({
   );
 }
 
-function QdrantConfig({ settings, onChange }: Props<QdrantSettings>) {
+function QdrantConfig({ settings, secrets, secretsSet, onChange, onChangeSecrets }: Props<QdrantSettings> & SecretProps) {
   const s = useStyles2(getStyles);
   return (
     <>
@@ -222,6 +222,19 @@ function QdrantConfig({ settings, onChange }: Props<QdrantSettings>) {
           onChange={(e) => onChange({ ...settings, secure: e.currentTarget.checked })}
         />
       </Field>
+      {settings?.secure && (
+        <Field label="API key" description="API key for the qdrant gRPC server">
+          <SecretInput
+            name="qdrantApiKey"
+            width={s.inlineFieldInputWidth}
+            data-testid={testIds.appConfig.qdrantApiKey}
+            onChange={(e) => onChangeSecrets({ ...secrets, qdrantApiKey: e.currentTarget.value })}
+            onReset={() => onChangeSecrets({ ...secrets, qdrantApiKey: '' })}
+            isConfigured={secretsSet.qdrantApiKey ?? false}
+            value={secrets.qdrantApiKey}
+          />
+        </Field>
+      )}
     </>
   );
 }
@@ -271,7 +284,10 @@ function StoreConfig({
       {settings?.type === 'qdrant' && (
         <QdrantConfig
           settings={settings.qdrant}
+          secrets={secrets}
+          secretsSet={secretsSet}
           onChange={(qdrant) => onChange({ ...settings, qdrant })}
+          onChangeSecrets={onChangeSecrets}
         />
       )}
       {settings?.type === 'grafana/vectorapi' && (

--- a/src/components/testIds.ts
+++ b/src/components/testIds.ts
@@ -8,6 +8,7 @@ export const testIds = {
     vectorEnabled: 'data-testid ac-vector-enabled',
     qdrantAddress: 'data-testid ac-qdrant-address',
     qdrantSecure: 'data-testid ac-qdrant-secure',
+    qdrantApiKey: 'data-testid ac-qdrant-api-key',
     grafanaVectorApiUrl: 'data-testid ac-grafana-vector-api-url',
     model: 'data-testid ac-vector-model',
     submit: 'data-testid ac-submit-form',


### PR DESCRIPTION
The Qdrant settings interface did not allow users to modify the qdrantApiKey field, even though this field is understood by the plugin backend and documented in the README. This PR adds the API key field to the Qdrant config when the 'secure' checkbox is checked.

Fixes #200.