### PR TITLE
limit health check to 1 token

### DIFF
--- a/pkg/plugin/health.go
+++ b/pkg/plugin/health.go
@@ -58,6 +58,7 @@ func (a *App) testOpenAIModel(ctx context.Context, model string, tenant string) 
 				"content": "Hello",
 			},
 		},
+		"max_tokens": 1,
 	}
 	req, err := a.newOpenAIChatCompletionsRequest(ctx, body, tenant)
 	if err != nil {


### PR DESCRIPTION
We don't need a full completion, just testing if the endpoint works