### PR TITLE
Fixed llm-gateway communication details for Grafana Cloud

### DIFF
--- a/pkg/plugin/health.go
+++ b/pkg/plugin/health.go
@@ -49,7 +49,7 @@ func getVersion() string {
 	return buildInfo.Version
 }
 
-func (a *App) testOpenAIModel(ctx context.Context, model string, tenant string) error {
+func (a *App) testOpenAIModel(ctx context.Context, model string) error {
 	body := map[string]interface{}{
 		"model": model,
 		"messages": []map[string]interface{}{
@@ -60,7 +60,7 @@ func (a *App) testOpenAIModel(ctx context.Context, model string, tenant string) 
 		},
 		"max_tokens": 1,
 	}
-	req, err := a.newOpenAIChatCompletionsRequest(ctx, body, tenant)
+	req, err := a.newOpenAIChatCompletionsRequest(ctx, body)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -97,7 +97,7 @@ func (a *App) openAIHealth(ctx context.Context, req *backend.CheckHealthRequest)
 		if d.Configured {
 			health.OK = true
 			health.Error = ""
-			err := a.testOpenAIModel(ctx, model, a.settings.Tenant)
+			err := a.testOpenAIModel(ctx, model)
 			if err != nil {
 				health.OK = false
 				health.Error = err.Error()

--- a/pkg/plugin/health.go
+++ b/pkg/plugin/health.go
@@ -88,7 +88,7 @@ func (a *App) openAIHealth(ctx context.Context, req *backend.CheckHealthRequest)
 
 	d := openAIHealthDetails{
 		OK:         true,
-		Configured: a.settings.OpenAI.apiKey != "",
+		Configured: a.settings.OpenAI.apiKey != "" || a.settings.OpenAI.Provider == openAIProviderGrafana,
 		Models:     map[string]openAIModelHealth{},
 	}
 

--- a/pkg/plugin/openai.go
+++ b/pkg/plugin/openai.go
@@ -11,7 +11,7 @@ import (
 	"path"
 )
 
-func (a *App) newAuthenticatedOpenAIRequest(ctx context.Context, method string, url url.URL, body io.Reader, tenant string) (*http.Request, error) {
+func (a *App) newAuthenticatedOpenAIRequest(ctx context.Context, method string, url url.URL, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), body)
 	if err != nil {
 		return nil, err
@@ -23,13 +23,13 @@ func (a *App) newAuthenticatedOpenAIRequest(ctx context.Context, method string, 
 	case openAIProviderAzure:
 		req.Header.Set("api-key", a.settings.OpenAI.apiKey)
 	case openAIProviderGrafana:
-		req.Header.Add("Authorization", "Basic "+a.settings.LLMGateway.apiKey)
-		req.Header.Add("X-Scope-OrgID", tenant)
+		req.SetBasicAuth(a.settings.Tenant, a.settings.GrafanaComAPIKey)
+		req.Header.Add("X-Scope-OrgID", a.settings.Tenant)
 	}
 	return req, nil
 }
 
-func (a *App) newOpenAIChatCompletionsRequest(ctx context.Context, body map[string]interface{}, tenant string) (*http.Request, error) {
+func (a *App) newOpenAIChatCompletionsRequest(ctx context.Context, body map[string]interface{}) (*http.Request, error) {
 	var url *url.URL
 	var err error
 
@@ -81,7 +81,7 @@ func (a *App) newOpenAIChatCompletionsRequest(ctx context.Context, body map[stri
 	if err != nil {
 		return nil, fmt.Errorf("marshal request body: %w", err)
 	}
-	req, err := a.newAuthenticatedOpenAIRequest(ctx, http.MethodPost, *url, bytes.NewReader(bodyBytes), tenant)
+	req, err := a.newAuthenticatedOpenAIRequest(ctx, http.MethodPost, *url, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}

--- a/pkg/plugin/openai.go
+++ b/pkg/plugin/openai.go
@@ -23,7 +23,7 @@ func (a *App) newAuthenticatedOpenAIRequest(ctx context.Context, method string, 
 	case openAIProviderAzure:
 		req.Header.Set("api-key", a.settings.OpenAI.apiKey)
 	case openAIProviderGrafana:
-		req.Header.Add("Authorization", "Bearer "+a.settings.LLMGateway.apiKey)
+		req.Header.Add("Authorization", "Basic "+a.settings.LLMGateway.apiKey)
 		req.Header.Add("X-Scope-OrgID", tenant)
 	}
 	return req, nil

--- a/pkg/plugin/openai.go
+++ b/pkg/plugin/openai.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 func (a *App) newAuthenticatedOpenAIRequest(ctx context.Context, method string, url url.URL, body io.Reader, tenant string) (*http.Request, error) {
@@ -70,7 +71,7 @@ func (a *App) newOpenAIChatCompletionsRequest(ctx context.Context, body map[stri
 		if err != nil {
 			return nil, fmt.Errorf("Unable to parse LLM Gateway URL: %w", err)
 		}
-		url.Path = "/openai/v1/chat/completions"
+		url.Path = path.Join(url.Path, "/openai/v1/chat/completions")
 
 	default:
 		return nil, fmt.Errorf("Unknown OpenAI provider: %s", a.settings.OpenAI.Provider)

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -223,7 +223,7 @@ func (a *grafanaOpenAIProxy) ServeHTTP(w http.ResponseWriter, req *http.Request)
 
 func newGrafanaOpenAIProxy(settings Settings) http.Handler {
 	director := func(req *http.Request) {
-		req.Header.Add("Authorization", "Bearer "+settings.LLMGateway.apiKey)
+		req.SetBasicAuth(settings.Tenant, settings.GrafanaComAPIKey)
 		req.Header.Add("X-Scope-OrgID", settings.Tenant)
 	}
 

--- a/pkg/plugin/resources_test.go
+++ b/pkg/plugin/resources_test.go
@@ -295,8 +295,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			appSettings := backend.AppInstanceSettings{
 				JSONData: jsonData,
 				DecryptedSecureJSONData: map[string]string{
-					"openAIKey":     tc.apiKey,
-					"llmGatewayKey": tc.apiKey,
+					"openAIKey": tc.apiKey,
 				},
 			}
 			inst, err := NewApp(ctx, appSettings)

--- a/pkg/plugin/resources_test.go
+++ b/pkg/plugin/resources_test.go
@@ -200,7 +200,8 @@ func TestCallOpenAIProxy(t *testing.T) {
 			name: "grafana-managed llm gateway - opt in not set",
 
 			settings: Settings{
-				Tenant: "123",
+				Tenant:           "123",
+				GrafanaComAPIKey: "abcd1234",
 				OpenAI: OpenAISettings{
 					Provider: openAIProviderGrafana,
 				},
@@ -212,7 +213,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
 
 			expReqHeaders: http.Header{
-				"Authorization": {"Bearer abcd1234"},
+				"Authorization": {"Basic MTIzOmFiY2QxMjM0"},
 				"X-Scope-OrgID": {"123"},
 			},
 			expReqPath: "/openai/v1/chat/completions",
@@ -224,7 +225,8 @@ func TestCallOpenAIProxy(t *testing.T) {
 			name: "grafana-managed llm gateway - opt in set to true",
 
 			settings: Settings{
-				Tenant: "123",
+				Tenant:           "123",
+				GrafanaComAPIKey: "abcd1234",
 				OpenAI: OpenAISettings{
 					Provider: openAIProviderGrafana,
 				},
@@ -239,7 +241,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
 
 			expReqHeaders: http.Header{
-				"Authorization": {"Bearer abcd1234"},
+				"Authorization": {"Basic MTIzOmFiY2QxMjM0"},
 				"X-Scope-OrgID": {"123"},
 			},
 			expReqPath: "/openai/v1/chat/completions",
@@ -251,7 +253,8 @@ func TestCallOpenAIProxy(t *testing.T) {
 			name: "grafana-managed llm gateway - opt in set to false",
 
 			settings: Settings{
-				Tenant: "123",
+				Tenant:           "123",
+				GrafanaComAPIKey: "abcd1234",
 				OpenAI: OpenAISettings{
 					Provider: openAIProviderGrafana,
 				},
@@ -265,7 +268,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
 
 			expReqHeaders: http.Header{
-				"Authorization": {"Bearer abcd1234"},
+				"Authorization": {"Basic MTIzOmFiY2QxMjM0"},
 				"X-Scope-OrgID": {"123"},
 			},
 			expReqPath: "/openai/v1/chat/completions",

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -14,6 +14,7 @@ import (
 )
 
 const openAIKey = "openAIKey"
+const llmGatewayKey = "llmGatewayKey"
 const encodedTenantAndTokenKey = "base64EncodedAccessToken"
 
 type openAIProvider string
@@ -52,9 +53,6 @@ type LLMGatewaySettings struct {
 	// IsOptIn indicates if customer has enabled the Grafana Managed Key LLM.
 	// If not specified, this will be false.
 	IsOptIn bool `json:"isOptIn"`
-
-	//apiKey is the api key needed to authenticate requests to the LLM gateway. Stored securely.
-	apiKey string
 }
 
 // Settings contains the plugin's settings and secrets required by the plugin backend.
@@ -132,7 +130,6 @@ func loadSettings(appSettings backend.AppInstanceSettings) (*Settings, error) {
 
 	// Read user's OpenAI key & the LLMGateway key
 	settings.OpenAI.apiKey = appSettings.DecryptedSecureJSONData[openAIKey]
-	settings.LLMGateway.apiKey = appSettings.DecryptedSecureJSONData[encodedTenantAndTokenKey]
 
 	// TenantID and GrafanaCom token are combined as "tenantId:GComToken" and base64 encoded, the following undoes that.
 	encodedTenantAndToken, ok := appSettings.DecryptedSecureJSONData[encodedTenantAndTokenKey]

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -133,7 +133,7 @@ func loadSettings(appSettings backend.AppInstanceSettings) (*Settings, error) {
 
 	// Read user's OpenAI key & the LLMGateway key
 	settings.OpenAI.apiKey = appSettings.DecryptedSecureJSONData[openAIKey]
-	settings.LLMGateway.apiKey = appSettings.DecryptedSecureJSONData[llmGatewayKey]
+	settings.LLMGateway.apiKey = appSettings.DecryptedSecureJSONData[encodedTenantAndTokenKey]
 
 	// TenantID and GrafanaCom token are combined as "tenantId:GComToken" and base64 encoded, the following undoes that.
 	encodedTenantAndToken, ok := appSettings.DecryptedSecureJSONData[encodedTenantAndTokenKey]

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -14,7 +14,6 @@ import (
 )
 
 const openAIKey = "openAIKey"
-const llmGatewayKey = "llmGatewayKey"
 const encodedTenantAndTokenKey = "base64EncodedAccessToken"
 
 type openAIProvider string

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -37,7 +37,7 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 	// set stream to true
 	requestBody["stream"] = true
 
-	httpReq, err := a.newOpenAIChatCompletionsRequest(ctx, requestBody, a.settings.Tenant)
+	httpReq, err := a.newOpenAIChatCompletionsRequest(ctx, requestBody)
 	if err != nil {
 		return fmt.Errorf("proxy: stream: error creating request: %w", err)
 	}


### PR DESCRIPTION
Fix a couple communication details with Grafana Cloud llm-gateway:
- health check unconfigured logic considers the `provider == grafana` case
- Added missing cortex gateway path prefix which was previous discarded (e.g. `https://<gateway-url>/llm`)
- Updated the API key and auth method