### PR TITLE
Settings UI v2

### DIFF
--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -62,7 +62,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
   const validateInputs = (): string | undefined => {
     // Check if Grafana-provided OpenAI enabled, that it has been opted-in
     if (settings?.openAI?.provider === 'grafana' && !managedLLMOptIn) {
-      return "You must click the 'Enable OpenAI access via Grafana' button to use OpenAI provided by Grafana";
+      return 'You must click the "accept limited data sharing with OpenAI" checkbox to use OpenAI provided by Grafana';
     }
     return;
   };
@@ -110,7 +110,10 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
       const result = await checkPluginHealth(plugin.meta.id);
       setHealthCheck(result.data);
     }
-
+    // If moving away from Grafana-managed LLM, opt-out of the feature automatically
+    if (managedLLMOptIn && settings.openAI?.provider !== 'grafana') {
+      updateManagedLLMOptIn(false);
+    }
     setIsUpdating(false);
     setUpdated(false);
   };

--- a/src/components/AppConfig/LLMConfig.tsx
+++ b/src/components/AppConfig/LLMConfig.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Alert, Button, Card, Field, FieldSet, Icon, Modal, useStyles2 } from '@grafana/ui';
+import { Button, Card, Checkbox, FieldSet, Icon, useStyles2 } from '@grafana/ui';
 
 import { AppPluginSettings, Secrets, SecretsSet } from './AppConfig';
 import { OpenAIConfig, OpenAIProvider } from './OpenAI';
@@ -48,224 +48,105 @@ export function LLMConfig({
   // previousOpenAIProvider caches the value of the openAI provider, as it is overwritten by the grafana option
   const [previousOpenAIProvider, setPreviousOpenAIProvider] = useState<OpenAIProvider>();
 
-  // 2 modals: opt-in and opt-out
-  const [optInModalIsOpen, setOptInModalIsOpen] = useState<boolean>(false);
-  const [optOutModalIsOpen, setOptOutModalIsOpen] = useState<boolean>(false);
-  const showOptInModal = () => {
-    setOptInModalIsOpen(true);
-  };
-  const dismissOptInModal = () => {
-    setOptInModalIsOpen(false);
-    // TODO: Reset scroll position of the T&Cs.
-    setLLMOption('disabled');
-  };
-  const showOptOutModal = () => {
-    setOptOutModalIsOpen(true);
-  };
-  const dismissOptOutModal = () => {
-    setOptOutModalIsOpen(false);
-  };
-
-  const doOptIn = () => {
-    setOptIn(true);
-    setOptInModalIsOpen(false);
-
-    onChange({
-      ...settings,
-      openAI: { provider: 'grafana' },
-    });
-  };
-
-  const doOptOut = () => {
-    setOptIn(false);
-    dismissOptOutModal();
-
-    onChange({
-      ...settings,
-      openAI: { provider: undefined },
-    });
-    setLLMOption('disabled');
+  const optInChange = () => {
+    setOptIn(!optIn);
   };
 
   // Handlers for when different LLM options are chosen in the UI
   const selectLLMDisabled = () => {
-    // Cache if OpenAI or Azure is used, so can restore
-    if (previousOpenAIProvider !== undefined) {
-      setPreviousOpenAIProvider(settings.openAI?.provider);
-    }
+    if (llmOption !== 'disabled') {
+      // Cache if OpenAI or Azure provider is used, so can restore
+      if (previousOpenAIProvider === undefined) {
+        setPreviousOpenAIProvider(settings.openAI?.provider);
+      }
 
-    onChange({ ...settings, openAI: { provider: undefined } });
-    setLLMOption('disabled');
+      onChange({ ...settings, openAI: { provider: undefined } });
+      setLLMOption('disabled');
+    }
   };
 
-  const selectGrafanaManaged = () => {
-    // Cache if OpenAI or Azure is used, so can restore
-    if (previousOpenAIProvider !== undefined) {
-      setPreviousOpenAIProvider(settings.openAI?.provider);
-    }
+  const selectGrafanaManaged = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    if (llmOption !== 'grafana-provided') {
+      // Cache if OpenAI or Azure provider is used, so can restore
+      if (previousOpenAIProvider === undefined) {
+        setPreviousOpenAIProvider(settings.openAI?.provider);
+      }
 
-    onChange({ ...settings, openAI: { provider: 'grafana' } });
-    setLLMOption('grafana-provided');
+      onChange({ ...settings, openAI: { provider: 'grafana' } });
+      setLLMOption('grafana-provided');
+    }
   };
 
   const selectOpenAI = () => {
-    // Restore the provider
-    const newSettings = { ...settings, openAI: { provider: previousOpenAIProvider } };
-    onChange(newSettings);
+    if (llmOption !== 'openai') {
+      // Restore the provider (OpenAI or Azure) & clear the cache
+      onChange({ ...settings, openAI: { provider: previousOpenAIProvider } });
+      setPreviousOpenAIProvider(undefined);
 
-    onChange({ ...settings, openAI: { provider: 'openai' } });
-    setLLMOption('openai');
+      setLLMOption('openai');
+    }
   };
 
   return (
-    <>
-      <Modal
-        title="Enable OpenAI access via Grafana"
-        isOpen={optInModalIsOpen}
-        onDismiss={dismissOptInModal}
-        onClickBackdrop={dismissOptInModal}
-      >
-        <Alert title="To enable OpenAI via Grafana, please note the following:" severity="info">
-          <ul>
-            <li>Some data from your Grafana instance will be sent to OpenAI.</li>
-            <li>Grafana imposes usage limits for this service.</li>
-          </ul>
-        </Alert>
-
-        <p>To proceed please agree to the following terms & conditions:</p>
-        <div className={s.divWithScrollbar}>
-          <h4>FIXME! Terms &amp; Conditions for the Grafana-managed OpenAI</h4>
-
-          <h5>1. Acceptance of Terms</h5>
-          <p>
-            By using the Grafana-managed OpenAI proxy service (the &quot;Service&quot;), you agree to be bound by these
-            Terms & Conditions (&quot;Terms&quot;). If you do not agree with these Terms, do not use the Service. The
-            Service acts as a bridge, forwarding your requests to OpenAI and returning responses. It&apos;s designed to
-            enhance your Grafana platform experience by leveraging OpenAI&apos;s capabilities.
-          </p>
-
-          <h5>2. Privacy & Data Exposure</h5>
-          <p>
-            Understand that by using the Service, certain data from your Grafana instance, including but not limited to,
-            metrics, logs, and dashboard configurations, may be exposed to OpenAI to fulfill your requests. Although we
-            strive to ensure the confidentiality and security of your data, by agreeing to these Terms, you grant us
-            permission to share this data with OpenAI as necessary. We encourage you to review both our privacy policy
-            and that of OpenAI to understand how your data is handled.
-          </p>
-
-          <h5>3. Usage Restrictions</h5>
-          <p>
-            The Service is provided for your personal and internal business use only. You are prohibited from using the
-            Service for any illegal or unauthorized purpose. Additionally, you must not attempt to gain unauthorized
-            access to the Service, other accounts, computer systems, or networks connected to the Service through
-            hacking, password mining, or any other means.
-          </p>
-
-          <h5>4. Service Modifications and Availability</h5>
-          <p>
-            We reserve the right at any time and from time to time to modify or discontinue, temporarily or permanently,
-            the Service (or any part thereof) with or without notice. You agree that we shall not be liable to you or to
-            any third party for any modification, suspension, or discontinuance of the Service. We do not guarantee the
-            availability of the Service and it may be subject to downtimes and periodic maintenance.
-          </p>
-
-          <h5>5. Limitation of Liability</h5>
-          <p>
-            To the fullest extent permitted by law, in no event will we, our affiliates, officers, employees, agents,
-            suppliers, or licensors be liable for any indirect, incidental, special, consequential, or exemplary
-            damages, including but not limited to, damages for loss of profits, goodwill, use, data, or other intangible
-            losses (even if we have been advised of the possibility of such damages), resulting from the use or the
-            inability to use the Service.
-          </p>
-
-          <h5>6. Changes to Terms</h5>
-          <p>
-            We reserve the right, at our sole discretion, to change, modify, add, or remove portions of these Terms at
-            any time. It is your responsibility to check these Terms periodically for changes. Your continued use of the
-            Service following the posting of changes will mean that you accept and agree to the changes.
-          </p>
-        </div>
-        <Modal.ButtonRow>
-          <Button variant="secondary" fill="outline" onClick={dismissOptInModal}>
-            Cancel
-          </Button>
-          <Button onClick={doOptIn}>I Agree</Button>
-        </Modal.ButtonRow>
-      </Modal>
-
-      <Modal
-        title="Disable OpenAI access via Grafana"
-        isOpen={optOutModalIsOpen}
-        onDismiss={dismissOptOutModal}
-        onClickBackdrop={dismissOptOutModal}
-      >
-        This will disable all Grafana&rsquo;s LLM features. Are you sure you want to continue?
-        <Modal.ButtonRow>
-          <Button variant="secondary" fill="outline" onClick={dismissOptOutModal}>
-            Cancel
-          </Button>
-          <Button onClick={doOptOut}>Disable</Button>
-        </Modal.ButtonRow>
-      </Modal>
-
-      <FieldSet label="OpenAI Settings" className={s.sidePadding}>
-        {allowGrafanaManagedLLM && (
-          <Card
-            isSelected={llmOption === 'grafana-provided'}
-            onClick={selectGrafanaManaged}
-            className={s.cardWithoutBottomMargin}
-          >
-            <Card.Heading>Use OpenAI provided by Grafana</Card.Heading>
-            <Card.Description>
-              Enable LLM features in Grafana by using a connection to OpenAI that is provided by Grafana
-            </Card.Description>
-            <Card.Figure>
-              <Icon name="grafana" size="lg" />
-            </Card.Figure>
-          </Card>
-        )}
-        {allowGrafanaManagedLLM && llmOption === 'grafana-provided' && (
-          <div className={s.optionDetails}>
-            <Field>
-              {optIn ? (
-                <>
-                  <p>
-                    You <b>have</b> enabled the Grafana-managed OpenAI.
-                  </p>
-                  <p>
-                    This means some data from your Grafana instance is being sent to OpenAI. Note that usage limits will
-                    apply.
-                  </p>
-                  <p>
-                    If you would like to disable this, click here:&nbsp;
-                    <Button onClick={showOptOutModal} variant="destructive" size="sm">
-                      Disable OpenAI access via Grafana
-                    </Button>
-                  </p>
-                </>
-              ) : (
-                <>
-                  <p>If you wish to use Grafana&rsquo;s LLM-based features, you must supply your own OpenAI key.</p>
-                  <p>Alternatively you can use the Grafana-managed LLM by opting-in by clicking here:</p>
-                  <Button onClick={showOptInModal} size="lg">
-                    Enable OpenAI access via Grafana
-                  </Button>
-                </>
-              )}
-            </Field>
-          </div>
-        )}
-
-        <Card isSelected={llmOption === 'openai'} onClick={selectOpenAI} className={s.cardWithoutBottomMargin}>
-          <Card.Heading>Use your own OpenAI account</Card.Heading>
-          <Card.Description>Enable LLM features in Grafana using your own OpenAI details</Card.Description>
+    <FieldSet label="OpenAI Settings" className={s.sidePadding}>
+      {allowGrafanaManagedLLM && (
+        <Card
+          isSelected={llmOption === 'grafana-provided'}
+          onClick={selectGrafanaManaged}
+          className={s.cardWithoutBottomMargin}
+        >
+          <Card.Heading>Use OpenAI provided by Grafana</Card.Heading>
+          <Card.Description>
+            <p>Enable LLM features in Grafana by using a connection to OpenAI that is provided by Grafana</p>
+            {llmOption === 'grafana-provided' && (
+              <>
+                <div className={s.openaiTermsBox}>
+                  <ul>
+                    <li>Grafana uses OpenAI’s API platform to provide LLM functionality.</li>
+                    <li>
+                      OpenAI does not train models on inputs or outputs of their API platform. OpenAI does retain data
+                      for a short time to provide the services and monitor for abuse. All data is encrypted in transit
+                      and at rest.
+                    </li>
+                    <li>
+                      Visit the OpenAI trust portal for more details:{' '}
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={(e) => window.open('https://trust.openai.com/', '_blank')}
+                      >
+                        https://trust.openai.com/
+                      </Button>
+                    </li>
+                    <li>
+                      AI features are clearly marked in Grafana, and each feature sends minimal data to OpenAI, and only
+                      on user request (for example, when someone clicks the button to request an Incident auto-summary).
+                    </li>
+                    <li>
+                      By enabling this integration, I accept that Grafana shares limited data to the OpenAI API as
+                      needed to provide LLM-powered features.
+                    </li>
+                  </ul>
+                </div>
+                <Checkbox
+                  value={optIn}
+                  onClick={optInChange}
+                  label="I accept limited data sharing with OpenAI as described above"
+                />
+              </>
+            )}
+          </Card.Description>
           <Card.Figure>
-            <OpenAILogo width={20} height={20} />
+            <Icon name="grafana" size="lg" />
           </Card.Figure>
         </Card>
+      )}
 
-        {llmOption === 'openai' && (
-          <div className={s.optionDetails}>
+      <Card isSelected={llmOption === 'openai'} onClick={selectOpenAI} className={s.cardWithoutBottomMargin}>
+        <Card.Heading>Use your own OpenAI account</Card.Heading>
+        <Card.Description>
+          <p>Enable LLM features in Grafana using your own OpenAI account</p>
+          {llmOption === 'openai' && (
             <OpenAIConfig
               settings={settings.openAI ?? {}}
               onChange={(openAI) => onChange({ ...settings, openAI })}
@@ -273,18 +154,21 @@ export function LLMConfig({
               secretsSet={secretsSet}
               onChangeSecrets={onChangeSecrets}
             />
-          </div>
-        )}
+          )}
+        </Card.Description>
+        <Card.Figure>
+          <OpenAILogo width={20} height={20} />
+        </Card.Figure>
+      </Card>
 
-        <Card isSelected={llmOption === 'disabled'} onClick={selectLLMDisabled} className={s.cardWithoutBottomMargin}>
-          <Card.Heading>Disable all LLM features in Grafana</Card.Heading>
-          <Card.Description>&nbsp;</Card.Description>
-          <Card.Figure>
-            <Icon name="times" size="lg" />
-          </Card.Figure>
-        </Card>
-      </FieldSet>
-    </>
+      <Card isSelected={llmOption === 'disabled'} onClick={selectLLMDisabled} className={s.cardWithoutBottomMargin}>
+        <Card.Heading>Disable all LLM features in Grafana</Card.Heading>
+        <Card.Description>&nbsp;</Card.Description>
+        <Card.Figure>
+          <Icon name="times" size="lg" />
+        </Card.Figure>
+      </Card>
+    </FieldSet>
   );
 }
 
@@ -293,24 +177,21 @@ export const getStyles = (theme: GrafanaTheme2) => ({
     margin-left: ${theme.spacing(1)};
     margin-right: ${theme.spacing(1)};
   `,
-  divWithScrollbar: css`
-    overflow-y: auto;
-    max-height: 450px;
-    margin-left: ${theme.spacing(1)};
-    margin-right: ${theme.spacing(1)};
-    padding: ${theme.spacing(1)};
-    border: 1px solid #383951;
+  nestedList: css`
+    margin-left: ${theme.spacing(3)};
   `,
-  optionDetails: css`
-    margin-left: ${theme.spacing(1)};
-    margin-right: ${theme.spacing(1)};
-    padding: ${theme.spacing(1)};
-    border: 1px solid #383951;
+  openaiTermsBox: css`
+    overflow-y: auto;
+    z-index: 2;
+    margin-right: ${theme.spacing(3)};
+    padding: ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(3)};
+    border: 1px solid ${theme.colors.border.medium};
+    background: ${theme.colors.background.primary};
+    color: ${theme.colors.text.primary};
   `,
   cardWithoutBottomMargin: css`
     margin-bottom: 0;
     margin-top: ${theme.spacing(1)};
-    height: 80px;
   `,
   inlineFieldWidth: 15,
   inlineFieldInputWidth: 40,

--- a/src/components/AppConfig/OpenAI.tsx
+++ b/src/components/AppConfig/OpenAI.tsx
@@ -43,7 +43,7 @@ export function OpenAIConfig({
     });
   };
   return (
-    <FieldSet label="Your OpenAI Account details">
+    <FieldSet>
       <Field label="OpenAI Provider">
         <Select
           data-testid={testIds.appConfig.openAIProvider}


### PR DESCRIPTION
Quick second iteration of the Settings UI, taking some design feedback into account and simplifying the flow:
- no more dialogs showing long terms & conditions, or opt-out message

Grafana-managed option:
<img width="1384" alt="image" src="https://github.com/grafana/grafana-llm-app/assets/632769/883514f0-d176-4584-853a-f59d92b96d49">

Own OpenAI a/c option:
<img width="1360" alt="image" src="https://github.com/grafana/grafana-llm-app/assets/632769/24553ba7-7ca2-49d7-b538-ae8a0babd4f5">
