### PR TITLE
Healthcheck fix when disabled, UI bug fixes

### DIFF
--- a/pkg/plugin/health.go
+++ b/pkg/plugin/health.go
@@ -88,7 +88,7 @@ func (a *App) openAIHealth(ctx context.Context, req *backend.CheckHealthRequest)
 
 	d := openAIHealthDetails{
 		OK:         true,
-		Configured: a.settings.OpenAI.apiKey != "" || a.settings.OpenAI.Provider == openAIProviderGrafana,
+		Configured: ((a.settings.OpenAI.Provider == openAIProviderAzure || a.settings.OpenAI.Provider == openAIProviderOpenAI) && a.settings.OpenAI.apiKey != "") || a.settings.OpenAI.Provider == openAIProviderGrafana,
 		Models:     map[string]openAIModelHealth{},
 	}
 
@@ -114,7 +114,7 @@ func (a *App) openAIHealth(ctx context.Context, req *backend.CheckHealthRequest)
 	}
 	if !anyOK {
 		d.OK = false
-		d.Error = "No models are working"
+		d.Error = "No functioning models are available"
 	}
 
 	// Only cache result if openAI is ok to use.

--- a/pkg/plugin/health_test.go
+++ b/pkg/plugin/health_test.go
@@ -57,7 +57,7 @@ func TestCheckHealth(t *testing.T) {
 			},
 			expDetails: healthCheckDetails{
 				OpenAI: openAIHealthDetails{
-					Error:  "No models are working",
+					Error:  "No functioning models are available",
 					Models: map[string]openAIModelHealth{},
 				},
 				Vector:  vectorHealthDetails{},
@@ -122,7 +122,7 @@ func TestCheckHealth(t *testing.T) {
 			vService: &mockVectorService{},
 			expDetails: healthCheckDetails{
 				OpenAI: openAIHealthDetails{
-					Error:  "No models are working",
+					Error:  "No functioning models are available",
 					Models: map[string]openAIModelHealth{},
 				},
 				Vector: vectorHealthDetails{
@@ -136,6 +136,9 @@ func TestCheckHealth(t *testing.T) {
 			name: "vector enabled with openai",
 			settings: backend.AppInstanceSettings{
 				JSONData: json.RawMessage(`{
+					"openai": {
+						"provider": "openai"
+					},
 					"vector": {
 						"enabled": true,
 						"embed": {

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -394,6 +394,11 @@ func (app *App) handleSaveLLMOptInState(w http.ResponseWriter, req *http.Request
 
 	user := httpadapter.UserFromContext(req.Context())
 
+	devMode := os.Getenv("DEV_MODE") != ""
+	if devMode {
+		user.Email = "admin@localhost.com"
+	}
+
 	if user == nil || user.Email == "" {
 		handleError(w, fmt.Errorf("valid user not found (please sign in and retry)"), http.StatusUnauthorized)
 		return

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -77,12 +77,7 @@ type Settings struct {
 }
 
 func loadSettings(appSettings backend.AppInstanceSettings) (*Settings, error) {
-	settings := Settings{
-		OpenAI: OpenAISettings{
-			URL:      "https://api.openai.com",
-			Provider: openAIProviderOpenAI,
-		},
-	}
+	settings := Settings{}
 
 	if len(appSettings.JSONData) != 0 {
 		err := json.Unmarshal(appSettings.JSONData, &settings)

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -68,11 +68,6 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
   };
   const errorState = validateInputs();
 
-  const updateManagedLLMOptIn = async (newOptIn: boolean): Promise<void> => {
-    await saveLLMOptInState(newOptIn);
-    setManagedLLMOptIn(newOptIn);
-  };
-
   useEffect(() => {
     const fetchData = async () => {
       const optIn = await getLLMOptInState();
@@ -83,6 +78,13 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
       fetchData();
     }
   }, [settings.enableGrafanaManagedLLM]);
+
+  useEffect(() => {
+    // clear health check status if any setting changed
+    if (updated) {
+      setHealthCheck(undefined);
+    }
+  }, [updated]);
 
   const doSave = async () => {
     if (errorState !== undefined) {
@@ -110,15 +112,25 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
       setIsUpdating(false);
       throw e;
     }
-    // If disabling LLM features, no health check needed
+
+    // Note: health-check uses the state saved in the plugin settings.
+    let healthCheckResult: HealthCheckResult | undefined = undefined;
     if (settings.openAI?.provider !== undefined) {
       const result = await checkPluginHealth(plugin.meta.id);
-      setHealthCheck(result.data);
+      healthCheckResult = result.data;
     }
+    setHealthCheck(healthCheckResult);
+
     // If moving away from Grafana-managed LLM, opt-out of the feature automatically
     if (managedLLMOptIn && settings.openAI?.provider !== 'grafana') {
-      updateManagedLLMOptIn(false);
+      await saveLLMOptInState(false);
+    } else {
+      await saveLLMOptInState(managedLLMOptIn);
     }
+
+    // Update the frontend settings explicitly, it is otherwise not updated until page reload
+    plugin.meta.jsonData = settings;
+
     setIsUpdating(false);
     setUpdated(false);
   };
@@ -134,7 +146,10 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
         secrets={newSecrets}
         secretsSet={configuredSecrets}
         optIn={managedLLMOptIn}
-        setOptIn={updateManagedLLMOptIn}
+        setOptIn={(optIn) => {
+          setManagedLLMOptIn(optIn);
+          setUpdated(true);
+        }}
         onChangeSecrets={(secrets: Secrets) => {
           // Update the new secrets.
           setNewSecrets(secrets);
@@ -238,9 +253,6 @@ export const updateAndSavePluginSettings = async (
   await updateGrafanaPluginSettings(pluginId, data).then((response: FetchResponse) => {
     if (!response.ok) {
       throw response.data;
-    } else {
-      // Reloading the page as the plugin meta changes made here wouldn't be propagated throughout the app.
-      window.location.reload();
     }
   });
 };

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -108,7 +108,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
       });
     } catch (e) {
       setIsUpdating(false);
-      throw (e);
+      throw e;
     }
     // If disabling LLM features, no health check needed
     if (settings.openAI?.provider !== undefined) {
@@ -212,13 +212,17 @@ export const updateGcomProvisionedPluginSettings = (data: Partial<PluginMeta>) =
   const response = getBackendSrv().fetch({
     url: `/api/plugins/grafana-llm-app/resources/save-plugin-settings`,
     method: 'POST',
-    data
+    data,
   });
 
   return lastValueFrom(response);
 };
 
-export const updateAndSavePluginSettings = async (pluginId: string, persistToGcom = false, data: Partial<PluginMeta>) => {
+export const updateAndSavePluginSettings = async (
+  pluginId: string,
+  persistToGcom = false,
+  data: Partial<PluginMeta>
+) => {
   const gcomPluginData = {
     jsonData: data.jsonData,
     secureJsonData: data.secureJsonData,
@@ -234,6 +238,9 @@ export const updateAndSavePluginSettings = async (pluginId: string, persistToGco
   await updateGrafanaPluginSettings(pluginId, data).then((response: FetchResponse) => {
     if (!response.ok) {
       throw response.data;
+    } else {
+      // Reloading the page as the plugin meta changes made here wouldn't be propagated throughout the app.
+      window.location.reload();
     }
   });
 };

--- a/src/components/AppConfig/LLMConfig.tsx
+++ b/src/components/AppConfig/LLMConfig.tsx
@@ -44,7 +44,8 @@ export function LLMConfig({
   const allowGrafanaManagedLLM = settings.enableGrafanaManagedLLM === true;
 
   // llmOption is the currently chosen LLM option in the UI
-  const [llmOption, setLLMOption] = useState<LLMOptions>(getLLMOptionFromSettings(settings));
+  const llmOption = getLLMOptionFromSettings(settings);
+
   // previousOpenAIProvider caches the value of the openAI provider, as it is overwritten by the grafana option
   const [previousOpenAIProvider, setPreviousOpenAIProvider] = useState<OpenAIProvider>();
 
@@ -61,7 +62,6 @@ export function LLMConfig({
       }
 
       onChange({ ...settings, openAI: { provider: undefined } });
-      setLLMOption('disabled');
     }
   };
 
@@ -73,7 +73,6 @@ export function LLMConfig({
       }
 
       onChange({ ...settings, openAI: { provider: 'grafana' } });
-      setLLMOption('grafana-provided');
     }
   };
 
@@ -86,11 +85,9 @@ export function LLMConfig({
         onChange({ ...settings, openAI: { provider: previousOpenAIProvider } });
         setPreviousOpenAIProvider(undefined);
       } else {
-        onChange({ ...settings, openAI: { provider: "openai" } });
+        onChange({ ...settings, openAI: { provider: 'openai' } });
         setPreviousOpenAIProvider(undefined);
       }
-
-      setLLMOption('openai');
     }
   };
 


### PR DESCRIPTION
This is a bunch of bug fixes:
1. if LLMs was disabled in the plugin config, the health check could still return a enabled LLM if a previous OpenAI API key was provided. The default state in the loadSettings() was the culprit.
2. Fix for bug #241. The plugin relies on the `jsonData` provided to it by Grafana to know its current state (read from the backend on plugin initialisation). If the config page changes the configuration, the plugin `jsonData` remains unchanged until a page reload happens. Fixed by pushing the new jsonData to the plugin on save.
3. Removal of some state duplication in LLMConfig (setLLMOption state was unnecessary)
4. Clear the health check results if user changes any setting.
5. I tightened up the health check (empty api key only permitted if llms disabled or grafana-managed).