### PR TITLE
fix: make sure the Grafana OpenAI proxy works when hosted at a subpath

### DIFF
--- a/pkg/plugin/resources_test.go
+++ b/pkg/plugin/resources_test.go
@@ -293,7 +293,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 				"Authorization": {"Basic MTIzOmFiY2QxMjM0"},
 				"X-Scope-OrgID": {"123"},
 			},
-			expReqPath: "/openai/v1/chat/completions",
+			expReqPath: "/llm/openai/v1/chat/completions",
 			expReqBody: []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
 
 			expStatus: http.StatusOK,
@@ -318,7 +318,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 				"Authorization": {"Basic MTIzOmFiY2QxMjM0"},
 				"X-Scope-OrgID": {"123"},
 			},
-			expReqPath: "/openai/v1/chat/completions",
+			expReqPath: "/llm/openai/v1/chat/completions",
 			expReqBody: []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
 
 			expStatus: http.StatusOK,
@@ -331,7 +331,8 @@ func TestCallOpenAIProxy(t *testing.T) {
 
 			// Update the OpenAI/LLMGateway URL with the mock server's URL.
 			if tc.settings.OpenAI.Provider == openAIProviderGrafana {
-				tc.settings.LLMGateway.URL = server.server.URL
+				// Make sure our tests work when the LLM gateway is at a subpath.
+				tc.settings.LLMGateway.URL = server.server.URL + "/llm"
 			} else {
 				tc.settings.OpenAI.URL = server.server.URL
 			}


### PR DESCRIPTION
Prior to this commit we ignored the path of the configured OpenAI API
when modifying the proxied URL of a request, so that even if the OpenAI
API URL was set to something like "https://foo.com/llm" we would still
proxy requests to "https://foo.com".

This commit preserves the path of the configured URL so that subpaths
are honoured in the outgoing proxied request from the plugin.

I also fixed a missing early return after failing to modify the URL.

Fixes https://github.com/grafana/incident/issues/5107.