### PR TITLE
Fix validate step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
           pushd ./plugin-validator/pkg/cmd/plugincheck2
           go install
           popd
-          plugincheck2 -config ./plugin-validator/config/default.yaml ${{ steps.metadata.outputs.upload-folder }}/${{ steps.metadata.outputs.archive }}
+          plugincheck2 -config ./plugin-validator/config/default.yaml __to-upload__/${{ steps.metadata.outputs.archive }}
 
       - name: Create tag
         uses: rickstaa/action-create-tag@v1


### PR DESCRIPTION
Oversight when pushing to new CI/CD left a variable for this step unpopulated, should be an easy fix.