### PR TITLE
Only apply saveLLMOptInState when enableGrafanaManagedLLM is enabled

### DIFF
--- a/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
@@ -122,10 +122,13 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
     setHealthCheck(healthCheckResult);
 
     // If moving away from Grafana-managed LLM, opt-out of the feature automatically
-    if (managedLLMOptIn && settings.openAI?.provider !== 'grafana') {
-      await saveLLMOptInState(false);
-    } else {
-      await saveLLMOptInState(managedLLMOptIn);
+    // This logic should only be triggered if the Grafana-managed LLM feature is enabled (Grafana Cloud Only)
+    if (settings.enableGrafanaManagedLLM === true) {
+      if (managedLLMOptIn && settings.openAI?.provider !== 'grafana') {
+        await saveLLMOptInState(false);
+      } else {
+        await saveLLMOptInState(managedLLMOptIn);
+      }
     }
 
     // Update the frontend settings explicitly, it is otherwise not updated until page reload


### PR DESCRIPTION
Currently `saveLLMOptInState` is called even when `enableGrafanaManagedLLM` is not set.

This causes issues with OSS version of this plugin since the llm-gateway call will fail.