### PR TITLE
add LLM app plugin keywords

### DIFF
--- a/packages/grafana-llm-app/src/plugin.json
+++ b/packages/grafana-llm-app/src/plugin.json
@@ -9,7 +9,7 @@
   "preload": true,
   "info": {
     "keywords": [
-      "app", "generative", "AI", "LLM", "assistant"
+      "app", "generative", "AI", "LLM", "OpenAI", "assistant"
     ],
     "description": "Plugin to easily allow LLM based extensions to grafana",
     "author": {


### PR DESCRIPTION
The new plugins search uses keywords (if you set them):
https://grafana.com/docs/grafana-cloud/whats-new/#plugin-search-improvements

Any others I missed?