### PR TITLE
Add flag to allow optional display vector store setting

### DIFF
--- a/packages/grafana-llm-app/provisioning/plugins/grafana-vector-api/grafana-llm-app.yaml
+++ b/packages/grafana-llm-app/provisioning/plugins/grafana-vector-api/grafana-llm-app.yaml
@@ -5,6 +5,7 @@ apps:
     jsonData:
       base64EncodedAccessTokenSet: True
       # enableGrafanaManagedLLM: True
+      # displayVectorStoreOptions: False
       openAI:
         provider: openai
         url: https://api.openai.com

--- a/packages/grafana-llm-app/src/components/AppConfig/AppConfig.test.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AppConfig.test.tsx
@@ -18,6 +18,7 @@ describe('Components/AppConfig', () => {
           type: PluginType.app,
           enabled: true,
           jsonData: {
+            displayVectorStoreOptions: true,
             vector: {
               enabled: true,
               store: {

--- a/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
@@ -20,6 +20,7 @@ export interface AppPluginSettings {
   // The enableGrafanaManagedLLM flag will enable the plugin to use Grafana-managed OpenAI
   // This will only work for Grafana Cloud install plugins
   enableGrafanaManagedLLM?: boolean;
+  displayVectorStoreOptions?: boolean;
 }
 
 export type Secrets = {
@@ -164,26 +165,27 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
           setUpdated(true);
         }}
       />
-
-      <VectorConfig
-        settings={settings.vector}
-        secrets={newSecrets}
-        secretsSet={configuredSecrets}
-        onChange={(vector) => {
-          setSettings({ ...settings, vector });
-          setUpdated(true);
-        }}
-        onChangeSecrets={(secrets) => {
-          // Update the new secrets.
-          setNewSecrets(secrets);
-          // Mark each secret as not configured. This will cause it to be included
-          // in the request body when the user clicks "Save settings".
-          for (const key of Object.keys(secrets)) {
-            setConfiguredSecrets({ ...configuredSecrets, [key]: false });
-          }
-          setUpdated(true);
-        }}
-      />
+      {settings.displayVectorStoreOptions === true &&
+        <VectorConfig
+          settings={settings.vector}
+          secrets={newSecrets}
+          secretsSet={configuredSecrets}
+          onChange={(vector) => {
+            setSettings({ ...settings, vector });
+            setUpdated(true);
+          }}
+          onChangeSecrets={(secrets) => {
+            // Update the new secrets.
+            setNewSecrets(secrets);
+            // Mark each secret as not configured. This will cause it to be included
+            // in the request body when the user clicks "Save settings".
+            for (const key of Object.keys(secrets)) {
+              setConfiguredSecrets({ ...configuredSecrets, [key]: false });
+            }
+            setUpdated(true);
+          }}
+        />
+      }
 
       {errorState !== undefined && <Alert title={errorState} severity="error" />}
       {isUpdating ? (


### PR DESCRIPTION
Vector store is not currently use in any GA Grafana features. Including it can cause confusion especially in provisioned Grafana cloud instances.

Adding a `displayVectorStoreOptions` flag to optionally display the vector store configs.