### PR TITLE
stream_test: more realistic data + test happy path

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/stream.go
+++ b/packages/grafana-llm-app/pkg/plugin/stream.go
@@ -70,6 +70,12 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 			return nil
 		case event := <-eventStream.Events:
 			var body map[string]interface{}
+			if event == nil {
+				// make sure we have an event, otherwise, event.Data will be empty panic
+				// this can happen if for final messages with no data, e.g. "event: done\n\n"
+				log.DefaultLogger.Debug(fmt.Sprintf("proxy: stream: event is nil, ending (in happy branch): %s", req.Path))
+				return nil
+			}
 			eventData := event.Data()
 			// If the event data is "[DONE]", then we're done.
 			if eventData == "[DONE]" {


### PR DESCRIPTION
This PR 
- fixes handling of `event: done` message (sent before `data: [DONE]`) to avoid sending the [DONE] message twice
- fix panic that happens when the stream ends without a DONE message
```
--- FAIL: TestRunStream/happy_path_without_EOF (0.00s)
--- FAIL: TestRunStream (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1050c9c64]
```
- add streaming tests for happy path

We specifically hit https://github.com/launchdarkly/eventsource/blob/de1f74c2fe7f51a8b7d1a9bef13f76b01656916b/decoder.go#L148 ~when the done events are sent~ when the stream ends without a done messages. 

This is quick fix to avoid a panic when we do, but in the future we should consider an alternative option (e.g. using something like the streamreader from https://github.com/sashabaranov/go-openai/blob/master/stream_reader.go)
