### PR TITLE
Abstract models to allow more providers

### DIFF
--- a/packages/grafana-llm-app/llmclient/llmclient.go
+++ b/packages/grafana-llm-app/llmclient/llmclient.go
@@ -31,6 +31,7 @@ const (
 	ModelLarge = "large"
 )
 
+// ChatCompletionRequest is a request for chat completions using an abstract model.
 type ChatCompletionRequest struct {
 	openai.ChatCompletionRequest
 	Model Model `json:"model"`

--- a/packages/grafana-llm-app/llmclient/llmclient_test.go
+++ b/packages/grafana-llm-app/llmclient/llmclient_test.go
@@ -1,0 +1,63 @@
+package llmclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func TestChatCompletions(t *testing.T) {
+	ctx := context.Background()
+	key := "test"
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/plugins/grafana-llm-app/resources/openai/v1/chat/completions" {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte("404 page not found"))
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+		if r.Header.Get("Authorization") != "Bearer "+key {
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+		req := openai.ChatCompletionRequest{}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		response := openai.ChatCompletionResponse{
+			ID:    "test",
+			Model: "test",
+			Choices: []openai.ChatCompletionChoice{
+				{Message: openai.ChatCompletionMessage{Role: "system", Content: "test"}},
+				{Message: openai.ChatCompletionMessage{Role: "user", Content: "test"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		j, _ := json.Marshal(response)
+		w.Write(j)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	// Create a mock OpenAI client
+	client := NewOpenAI(server.URL, key)
+	// Test case: Chat completions request succeeds
+	req := ChatCompletionRequest{
+		ChatCompletionRequest: openai.ChatCompletionRequest{
+			Messages: []openai.ChatCompletionMessage{
+				{Role: "system", Content: "/start"},
+				{Role: "user", Content: "Hello, how are you?"},
+			},
+		},
+		Model: ModelSmall,
+	}
+	_, err := client.ChatCompletions(ctx, req)
+	if err != nil {
+		t.Errorf("Expected no error, but got: %v", err)
+	}
+}

--- a/packages/grafana-llm-app/pkg/plugin/azure_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/azure_provider.go
@@ -1,0 +1,83 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type azure struct {
+	settings OpenAISettings
+	c        *http.Client
+}
+
+func NewAzureProvider(settings OpenAISettings) LLMProvider {
+	return &azure{
+		settings: settings,
+		c: &http.Client{
+			Timeout: 2 * time.Minute,
+		},
+	}
+}
+
+func (p *azure) Models(ctx context.Context) (ModelResponse, error) {
+	models := make([]ModelInfo, 0, len(p.settings.AzureMapping))
+	mapping, err := p.getAzureMapping()
+	if err != nil {
+		return ModelResponse{}, err
+	}
+	for model := range mapping {
+		models = append(models, ModelInfo{ID: model})
+	}
+	return ModelResponse{Data: models}, nil
+}
+
+type azureChatCompletionRequest struct {
+	ChatCompletionRequest
+	// Azure does not use the model field.
+	Model string `json:"-"`
+}
+
+func (p *azure) ChatCompletions(ctx context.Context, req ChatCompletionRequest) (ChatCompletionsResponse, error) {
+	mapping, err := p.getAzureMapping()
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
+	deployment := mapping[req.Model]
+	if deployment == "" {
+		return ChatCompletionsResponse{}, fmt.Errorf("%w: no deployment found for model: %s", errBadRequest, req.Model)
+	}
+
+	u, err := url.Parse(p.settings.URL)
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
+	u.Path = fmt.Sprintf("/openai/deployments/%s/chat/completions", deployment)
+	u.RawQuery = "api-version=2023-03-15-preview"
+	reqBody, err := json.Marshal(azureChatCompletionRequest{
+		ChatCompletionRequest: req,
+		Model:                 req.Model.toOpenAI(),
+	})
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(reqBody))
+	httpReq.Header.Set("api-key", p.settings.apiKey)
+	return doOpenAIRequest(p.c, httpReq)
+}
+
+func (p *azure) getAzureMapping() (map[Model]string, error) {
+	result := make(map[Model]string, len(p.settings.AzureMapping))
+	for _, v := range p.settings.AzureMapping {
+		if len(v) != 2 {
+			return nil, fmt.Errorf("%w: expected 2 entries in a mapping, got %d", errBadRequest, len(v))
+		}
+		model, err := ModelFromString(v[0])
+		if err != nil {
+			return nil, err
+		}
+		result[model] = v[1]
+	}
+	return result, nil
+}

--- a/packages/grafana-llm-app/pkg/plugin/azure_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/azure_provider.go
@@ -62,7 +62,13 @@ func (p *azure) ChatCompletions(ctx context.Context, req ChatCompletionRequest) 
 		ChatCompletionRequest: req,
 		Model:                 req.Model.toOpenAI(),
 	})
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(reqBody))
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
 	httpReq.Header.Set("api-key", p.settings.apiKey)
 	return doOpenAIRequest(p.c, httpReq)
 }

--- a/packages/grafana-llm-app/pkg/plugin/grafana_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/grafana_provider.go
@@ -43,10 +43,16 @@ func (p *grafanaProvider) ChatCompletions(ctx context.Context, req ChatCompletio
 	}
 	// We keep the openai prefix when using llm-gateway.
 	u.Path, err = url.JoinPath(u.Path, "openai/v1/chat/completions")
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
 	reqBody, err := json.Marshal(openAIChatCompletionRequest{
 		ChatCompletionRequest: req,
 		Model:                 req.Model.toOpenAI(),
 	})
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(reqBody))
 	if err != nil {
 		return ChatCompletionsResponse{}, err

--- a/packages/grafana-llm-app/pkg/plugin/grafana_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/grafana_provider.go
@@ -30,8 +30,9 @@ func NewGrafanaProvider(settings Settings) LLMProvider {
 func (p *grafanaProvider) Models(ctx context.Context) (ModelResponse, error) {
 	return ModelResponse{
 		Data: []ModelInfo{
-			{ID: ModelDefault},
-			{ID: ModelHighAccuracy},
+			{ID: ModelSmall},
+			{ID: ModelMedium},
+			{ID: ModelLarge},
 		},
 	}, nil
 }

--- a/packages/grafana-llm-app/pkg/plugin/grafana_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/grafana_provider.go
@@ -1,0 +1,57 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type grafanaProvider struct {
+	settings LLMGatewaySettings
+	tenant   string
+	gcomKey  string
+	c        *http.Client
+}
+
+func NewGrafanaProvider(settings Settings) LLMProvider {
+	return &grafanaProvider{
+		settings: settings.LLMGateway,
+		tenant:   settings.Tenant,
+		gcomKey:  settings.GrafanaComAPIKey,
+		c: &http.Client{
+			Timeout: 2 * time.Minute,
+		},
+	}
+}
+
+func (p *grafanaProvider) Models(ctx context.Context) (ModelResponse, error) {
+	return ModelResponse{
+		Data: []ModelInfo{
+			{ID: ModelDefault},
+			{ID: ModelHighAccuracy},
+		},
+	}, nil
+}
+
+func (p *grafanaProvider) ChatCompletions(ctx context.Context, req ChatCompletionRequest) (ChatCompletionsResponse, error) {
+	u, err := url.Parse(p.settings.URL)
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
+	// We keep the openai prefix when using llm-gateway.
+	u.Path, err = url.JoinPath(u.Path, "openai/v1/chat/completions")
+	reqBody, err := json.Marshal(openAIChatCompletionRequest{
+		ChatCompletionRequest: req,
+		Model:                 req.Model.toOpenAI(),
+	})
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(reqBody))
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
+	httpReq.SetBasicAuth(p.tenant, p.gcomKey)
+	httpReq.Header.Add("X-Scope-OrgID", p.tenant)
+	return doOpenAIRequest(p.c, httpReq)
+}

--- a/packages/grafana-llm-app/pkg/plugin/health.go
+++ b/packages/grafana-llm-app/pkg/plugin/health.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/build"
 )
 
-var openAIModels = []string{"gpt-3.5-turbo", "gpt-4"}
+var openAIModels = []Model{ModelSmall, ModelMedium}
 
 type healthCheckClient interface {
 	Do(req *http.Request) (*http.Response, error)
@@ -23,10 +23,10 @@ type openAIModelHealth struct {
 }
 
 type openAIHealthDetails struct {
-	Configured bool                         `json:"configured"`
-	OK         bool                         `json:"ok"`
-	Error      string                       `json:"error,omitempty"`
-	Models     map[string]openAIModelHealth `json:"models"`
+	Configured bool                        `json:"configured"`
+	OK         bool                        `json:"ok"`
+	Error      string                      `json:"error,omitempty"`
+	Models     map[Model]openAIModelHealth `json:"models"`
 }
 
 type vectorHealthDetails struct {
@@ -49,9 +49,9 @@ func getVersion() string {
 	return buildInfo.Version
 }
 
-func (a *App) testOpenAIModel(ctx context.Context, model string) error {
+func (a *App) testOpenAIModel(ctx context.Context, model Model) error {
 	body := map[string]interface{}{
-		"model": model,
+		"model": model.toOpenAI(),
 		"messages": []map[string]interface{}{
 			{
 				"role":    "user",
@@ -89,7 +89,7 @@ func (a *App) openAIHealth(ctx context.Context, req *backend.CheckHealthRequest)
 	d := openAIHealthDetails{
 		OK:         true,
 		Configured: ((a.settings.OpenAI.Provider == openAIProviderAzure || a.settings.OpenAI.Provider == openAIProviderOpenAI) && a.settings.OpenAI.apiKey != "") || a.settings.OpenAI.Provider == openAIProviderGrafana,
-		Models:     map[string]openAIModelHealth{},
+		Models:     map[Model]openAIModelHealth{},
 	}
 
 	for _, model := range openAIModels {

--- a/packages/grafana-llm-app/pkg/plugin/health_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/health_test.go
@@ -58,7 +58,7 @@ func TestCheckHealth(t *testing.T) {
 			expDetails: healthCheckDetails{
 				OpenAI: openAIHealthDetails{
 					Error:  "No functioning models are available",
-					Models: map[string]openAIModelHealth{},
+					Models: map[Model]openAIModelHealth{},
 				},
 				Vector:  vectorHealthDetails{},
 				Version: "unknown",
@@ -88,9 +88,9 @@ func TestCheckHealth(t *testing.T) {
 				OpenAI: openAIHealthDetails{
 					Configured: true,
 					OK:         true,
-					Models: map[string]openAIModelHealth{
-						"gpt-3.5-turbo": {OK: true, Error: ""},
-						"gpt-4":         {OK: false, Error: `unexpected status code: 404: {"error": "model does not exist"}`},
+					Models: map[Model]openAIModelHealth{
+						ModelSmall:  {OK: true, Error: ""},
+						ModelMedium: {OK: false, Error: `unexpected status code: 404: {"error": "model does not exist"}`},
 					},
 				},
 				Vector:  vectorHealthDetails{},
@@ -123,7 +123,7 @@ func TestCheckHealth(t *testing.T) {
 			expDetails: healthCheckDetails{
 				OpenAI: openAIHealthDetails{
 					Error:  "No functioning models are available",
-					Models: map[string]openAIModelHealth{},
+					Models: map[Model]openAIModelHealth{},
 				},
 				Vector: vectorHealthDetails{
 					Enabled: true,
@@ -170,9 +170,9 @@ func TestCheckHealth(t *testing.T) {
 					Configured: true,
 					OK:         true,
 					Error:      "",
-					Models: map[string]openAIModelHealth{
-						"gpt-3.5-turbo": {OK: true, Error: ""},
-						"gpt-4":         {OK: false, Error: `unexpected status code: 404: {"error": "model does not exist"}`},
+					Models: map[Model]openAIModelHealth{
+						ModelSmall:  {OK: true, Error: ""},
+						ModelMedium: {OK: false, Error: `unexpected status code: 404: {"error": "model does not exist"}`},
 					},
 				},
 				Vector: vectorHealthDetails{

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider.go
@@ -1,0 +1,127 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var errBadRequest = errors.New("bad request")
+
+type Model string
+
+const (
+	ModelDefault      = "default"
+	ModelHighAccuracy = "high_accuracy"
+)
+
+// UnmarshalJSON accepts either OpenAI named models for backwards
+// compatability, or the new abstract model names.
+func ModelFromString(m string) (Model, error) {
+	switch m {
+	case "gpt-3.5-turbo", ModelDefault:
+		return ModelDefault, nil
+	case "gpt-4", ModelHighAccuracy:
+		return ModelHighAccuracy, nil
+	}
+	return "", fmt.Errorf("unrecognized model: %s", m)
+}
+
+// UnmarshalJSON accepts either OpenAI named models for backwards
+// compatability, or the new abstract model names.
+func (m *Model) UnmarshalJSON(data []byte) error {
+	switch string(data) {
+	case `"gpt-3.5-turbo"`, fmt.Sprintf(`"%s"`, ModelDefault):
+		*m = ModelDefault
+		return nil
+	case `"gpt-4"`, fmt.Sprintf(`"%s"`, ModelHighAccuracy):
+		*m = ModelHighAccuracy
+		return nil
+	}
+	return fmt.Errorf("unrecognized model: %s", string(data))
+}
+
+func (m Model) toOpenAI() string {
+	switch m {
+	case ModelDefault:
+		return "gpt-3.5-turbo"
+	case ModelHighAccuracy:
+		return "gpt-4"
+	}
+	panic("unknown model: " + m)
+}
+
+type Role string
+
+const (
+	RoleSystem    = "system"
+	RoleUser      = "user"
+	RoleAssistant = "assistant"
+)
+
+type Message struct {
+	Role    Role   `json:"role"`
+	Content string `json:"content"`
+}
+
+type ChatCompletionRequest struct {
+	Model       Model     `json:"model"`
+	Messages    []Message `json:"messages"`
+	Temperature *float64  `json:"temperature,omitempty"`
+	TopP        *float64  `json:"top_p,omitempty"`
+	MaxTokens   *int      `json:"max_tokens,omitempty"`
+}
+
+type ChatCompletionsResponse struct {
+	ID      string   `json:"id"`
+	Object  string   `json:"object"`
+	Created int64    `json:"created"`
+	Model   string   `json:"model"`
+	Choices []Choice `json:"choices"`
+	Usage   Usage    `json:"usage"`
+}
+
+type Choice struct {
+	Message Message `json:"message"`
+}
+
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type StreamChatCompletionResponse struct {
+	ID      string                       `json:"id"`
+	Object  string                       `json:"object"`
+	Created int64                        `json:"created"`
+	Model   string                       `json:"model"`
+	Choices []ChatCompletionStreamChoice `json:"choices"`
+}
+
+type ChatCompletionStreamChoice struct {
+	Delta        ChoiceDelta `json:"delta"`
+	FinishReason *string     `json:"finish_reason"`
+}
+
+type ChoiceDelta struct {
+	Content string `json:"content"`
+	Role    string `json:"role"`
+}
+
+type ModelResponse struct {
+	Data []ModelInfo `json:"data"`
+}
+
+type ModelInfo struct {
+	ID Model `json:"id"`
+}
+
+type LLMProvider interface {
+	// Models returns a list of models
+	Models(context.Context) (ModelResponse, error)
+	ChatCompletions(context.Context, ChatCompletionRequest) (ChatCompletionsResponse, error)
+	// TODO: Add StreamChatCompletions to this interface so we have one place
+	// to implement a new provider.
+	// StreamChatCompletions(context.Context, ChatCompletionRequest) (<-chan StreamChatCompletionResponse, error)
+}

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 var errBadRequest = errors.New("bad request")
@@ -18,10 +19,10 @@ const (
 // UnmarshalJSON accepts either OpenAI named models for backwards
 // compatability, or the new abstract model names.
 func ModelFromString(m string) (Model, error) {
-	switch m {
-	case "gpt-3.5-turbo", ModelDefault:
+	switch {
+	case strings.HasPrefix(m, "gpt-3.5") || m == ModelDefault:
 		return ModelDefault, nil
-	case "gpt-4", ModelHighAccuracy:
+	case strings.HasPrefix(m, "gpt-4") || m == ModelHighAccuracy:
 		return ModelHighAccuracy, nil
 	}
 	return "", fmt.Errorf("unrecognized model: %s", m)
@@ -30,15 +31,16 @@ func ModelFromString(m string) (Model, error) {
 // UnmarshalJSON accepts either OpenAI named models for backwards
 // compatability, or the new abstract model names.
 func (m *Model) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case `"gpt-3.5-turbo"`, fmt.Sprintf(`"%s"`, ModelDefault):
+	dataString := string(data)
+	switch {
+	case dataString == fmt.Sprintf(`"%s"`, ModelDefault) || strings.HasPrefix(dataString, `"gpt-3.5`):
 		*m = ModelDefault
 		return nil
-	case `"gpt-4"`, fmt.Sprintf(`"%s"`, ModelHighAccuracy):
+	case dataString == fmt.Sprintf(`"%s"`, ModelHighAccuracy) || strings.HasPrefix(dataString, `"gpt-4`):
 		*m = ModelHighAccuracy
 		return nil
 	}
-	return fmt.Errorf("unrecognized model: %s", string(data))
+	return fmt.Errorf("unrecognized model: %s", dataString)
 }
 
 func (m Model) toOpenAI() string {

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider.go
@@ -13,7 +13,7 @@ type Model string
 
 const (
 	ModelDefault      = "default"
-	ModelHighAccuracy = "high_accuracy"
+	ModelHighAccuracy = "high-accuracy"
 )
 
 // UnmarshalJSON accepts either OpenAI named models for backwards

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider_test.go
@@ -27,7 +27,7 @@ func TestModelFromString(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			input:    "high_accuracy",
+			input:    "high-accuracy",
 			expected: ModelHighAccuracy,
 			wantErr:  false,
 		},

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider_test.go
@@ -1,0 +1,68 @@
+package plugin
+
+import (
+	"testing"
+)
+
+func TestModelFromString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Model
+		wantErr  bool
+	}{
+		{
+			input:    "default",
+			expected: ModelDefault,
+			wantErr:  false,
+		},
+		{
+			input:    "gpt-3.5-turbo",
+			expected: ModelDefault,
+			wantErr:  false,
+		},
+		{
+			input:    "gpt-3.5-turbo-0125",
+			expected: ModelDefault,
+			wantErr:  false,
+		},
+		{
+			input:    "high_accuracy",
+			expected: ModelHighAccuracy,
+			wantErr:  false,
+		},
+		{
+			input:    "gpt-4",
+			expected: ModelHighAccuracy,
+			wantErr:  false,
+		},
+		{
+			input:    "gpt-4-turbo",
+			expected: ModelHighAccuracy,
+			wantErr:  false,
+		},
+		{
+			input:    "gpt-4-turbo-2024-04-09",
+			expected: ModelHighAccuracy,
+			wantErr:  false,
+		},
+		{
+			input:    "invalid_model",
+			expected: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ModelFromString(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ModelFromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("ModelFromString() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider_test.go
@@ -6,7 +6,6 @@ import (
 
 func TestModelFromString(t *testing.T) {
 	tests := []struct {
-		name     string
 		input    string
 		expected Model
 		wantErr  bool

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider_test.go
@@ -11,44 +11,63 @@ func TestModelFromString(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			input:    "default",
-			expected: ModelDefault,
+			input:    "small",
+			expected: ModelSmall,
 			wantErr:  false,
 		},
 		{
-			input:    "gpt-3.5-turbo",
-			expected: ModelDefault,
+			input:    "medium",
+			expected: ModelMedium,
 			wantErr:  false,
 		},
 		{
-			input:    "gpt-3.5-turbo-0125",
-			expected: ModelDefault,
+			input:    "large",
+			expected: ModelLarge,
 			wantErr:  false,
 		},
-		{
-			input:    "high-accuracy",
-			expected: ModelHighAccuracy,
-			wantErr:  false,
-		},
-		{
-			input:    "gpt-4",
-			expected: ModelHighAccuracy,
-			wantErr:  false,
-		},
-		{
-			input:    "gpt-4-turbo",
-			expected: ModelHighAccuracy,
-			wantErr:  false,
-		},
-		{
-			input:    "gpt-4-turbo-2024-04-09",
-			expected: ModelHighAccuracy,
-			wantErr:  false,
-		},
+
+		// unknown models
 		{
 			input:    "invalid_model",
 			expected: "",
 			wantErr:  true,
+		},
+		{
+			input:    "",
+			expected: "",
+			wantErr:  true,
+		},
+
+		// backwards-compatibility
+		{
+			input:    "gpt-3.5-turbo",
+			expected: ModelSmall,
+			wantErr:  false,
+		},
+		{
+			input:    "gpt-3.5-turbo-0125",
+			expected: ModelSmall,
+			wantErr:  false,
+		},
+		{
+			input:    "gpt-4-turbo",
+			expected: ModelMedium,
+			wantErr:  false,
+		},
+		{
+			input:    "gpt-4-turbo-2024-04-09",
+			expected: ModelMedium,
+			wantErr:  false,
+		},
+		{
+			input:    "gpt-4",
+			expected: ModelLarge,
+			wantErr:  false,
+		},
+		{
+			input:    "gpt-4-32k-0613",
+			expected: ModelLarge,
+			wantErr:  false,
 		},
 	}
 
@@ -61,6 +80,92 @@ func TestModelFromString(t *testing.T) {
 			}
 			if got != tt.expected {
 				t.Errorf("ModelFromString() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		input    []byte
+		expected Model
+		wantErr  bool
+	}{
+		{
+			input:    []byte(`"small"`),
+			expected: ModelSmall,
+			wantErr:  false,
+		},
+		{
+			input:    []byte(`"medium"`),
+			expected: ModelMedium,
+			wantErr:  false,
+		},
+		{
+			input:    []byte(`"large"`),
+			expected: ModelLarge,
+			wantErr:  false,
+		},
+
+		// unknown models
+		{
+			input:    []byte(`"invalid_model"`),
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			input:    []byte(`""`),
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			input:    []byte(`null`),
+			expected: "",
+			wantErr:  true,
+		},
+
+		// backwards-compatibility
+		{
+			input:    []byte(`"gpt-3.5-turbo"`),
+			expected: ModelSmall,
+			wantErr:  false,
+		},
+		{
+			input:    []byte(`"gpt-3.5-turbo-0125"`),
+			expected: ModelSmall,
+			wantErr:  false,
+		},
+		{
+			input:    []byte(`"gpt-4-turbo"`),
+			expected: ModelMedium,
+			wantErr:  false,
+		},
+		{
+			input:    []byte(`"gpt-4-turbo-2024-04-09"`),
+			expected: ModelMedium,
+			wantErr:  false,
+		},
+		{
+			input:    []byte(`"gpt-4"`),
+			expected: ModelLarge,
+			wantErr:  false,
+		},
+		{
+			input:    []byte(`"gpt-4-32k-0613"`),
+			expected: ModelLarge,
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			var m Model
+			err := m.UnmarshalJSON(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if m != tt.expected {
+				t.Errorf("UnmarshalJSON() = %v, expected %v", m, tt.expected)
 			}
 		})
 	}

--- a/packages/grafana-llm-app/pkg/plugin/openai_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/openai_provider.go
@@ -1,0 +1,84 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type openAI struct {
+	settings OpenAISettings
+	c        *http.Client
+}
+
+func NewOpenAIProvider(settings OpenAISettings) LLMProvider {
+	return &openAI{
+		settings: settings,
+		c: &http.Client{
+			Timeout: 2 * time.Minute,
+		},
+	}
+}
+
+func (p *openAI) Models(ctx context.Context) (ModelResponse, error) {
+	return ModelResponse{
+		Data: []ModelInfo{
+			{ID: ModelDefault},
+			{ID: ModelHighAccuracy},
+		},
+	}, nil
+}
+
+type openAIChatCompletionRequest struct {
+	ChatCompletionRequest
+	// Override the model field to just be a string rather than our custom Model type.
+	Model string `json:"model"`
+}
+
+func (p *openAI) ChatCompletions(ctx context.Context, req ChatCompletionRequest) (ChatCompletionsResponse, error) {
+	u, err := url.Parse(p.settings.URL)
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
+	u.Path, err = url.JoinPath(u.Path, "v1/chat/completions")
+	reqBody, err := json.Marshal(openAIChatCompletionRequest{
+		ChatCompletionRequest: req,
+		Model:                 req.Model.toOpenAI(),
+	})
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(reqBody))
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.settings.apiKey)
+	httpReq.Header.Set("OpenAI-Organization", p.settings.OrganizationID)
+	return doOpenAIRequest(p.c, httpReq)
+}
+
+func doOpenAIRequest(c *http.Client, req *http.Request) (ChatCompletionsResponse, error) {
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.Do(req)
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
+
+	if resp.StatusCode/100 != 2 {
+		return ChatCompletionsResponse{}, fmt.Errorf("error from OpenAI: %d, %s", resp.StatusCode, string(respBody))
+	}
+
+	completions := ChatCompletionsResponse{}
+	err = json.Unmarshal(respBody, &completions)
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
+	return completions, nil
+}

--- a/packages/grafana-llm-app/pkg/plugin/openai_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/openai_provider.go
@@ -46,10 +46,16 @@ func (p *openAI) ChatCompletions(ctx context.Context, req ChatCompletionRequest)
 		return ChatCompletionsResponse{}, err
 	}
 	u.Path, err = url.JoinPath(u.Path, "v1/chat/completions")
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
 	reqBody, err := json.Marshal(openAIChatCompletionRequest{
 		ChatCompletionRequest: req,
 		Model:                 req.Model.toOpenAI(),
 	})
+	if err != nil {
+		return ChatCompletionsResponse{}, err
+	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(reqBody))
 	if err != nil {
 		return ChatCompletionsResponse{}, err

--- a/packages/grafana-llm-app/pkg/plugin/openai_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/openai_provider.go
@@ -28,8 +28,9 @@ func NewOpenAIProvider(settings OpenAISettings) LLMProvider {
 func (p *openAI) Models(ctx context.Context) (ModelResponse, error) {
 	return ModelResponse{
 		Data: []ModelInfo{
-			{ID: ModelDefault},
-			{ID: ModelHighAccuracy},
+			{ID: ModelSmall},
+			{ID: ModelMedium},
+			{ID: ModelLarge},
 		},
 	}, nil
 }

--- a/packages/grafana-llm-app/pkg/plugin/resources.go
+++ b/packages/grafana-llm-app/pkg/plugin/resources.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"strings"
@@ -56,192 +55,6 @@ func modifyURL(openAIUrl string, req *http.Request) error {
 	// or '/openai/v1/chat/completions', depending on the OpenAI provider.
 	req.URL.Path, err = url.JoinPath("/", u.Path, req.URL.Path)
 	return err
-}
-
-// openAIProxy is a reverse proxy for OpenAI API calls.
-// It modifies the request to point to the configured OpenAI API, returning
-// a 400 error if the URL in settings cannot be parsed, then proxies the request
-// using the configured API key and OpenAI organization.
-type openAIProxy struct {
-	settings Settings
-	// rp is a reverse proxy handling the modified request. Use this rather than
-	// our own client, since it handles things like buffering.
-	rp *httputil.ReverseProxy
-}
-
-func (a *openAIProxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	err := modifyURL(a.settings.OpenAI.URL, req)
-	if err != nil {
-		// Attempt to write the error as JSON.
-		jd, err := json.Marshal(map[string]string{"error": err.Error()})
-		if err != nil {
-			// We can't write JSON, so just write the error string.
-			w.WriteHeader(http.StatusInternalServerError)
-			_, err = w.Write([]byte(err.Error()))
-			if err != nil {
-				log.DefaultLogger.Error("Unable to write error response", "err", err)
-			}
-			return
-		}
-		w.WriteHeader(http.StatusBadRequest)
-		_, err = w.Write(jd)
-		if err != nil {
-			log.DefaultLogger.Error("Unable to write error response", "err", err)
-		}
-		return
-	}
-	a.rp.ServeHTTP(w, req)
-}
-
-func newOpenAIProxy(settings Settings) http.Handler {
-	director := func(req *http.Request) {
-		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/openai")
-		req.Header.Add("Authorization", "Bearer "+settings.OpenAI.apiKey)
-		req.Header.Add("OpenAI-Organization", settings.OpenAI.OrganizationID)
-	}
-	return &openAIProxy{
-		settings: settings,
-		rp:       &httputil.ReverseProxy{Director: director},
-	}
-}
-
-// azureOpenAIProxy is a reverse proxy for Azure OpenAI API calls.
-// It modifies the request to point to the configured Azure OpenAI API, returning
-// a 400 error if the URL in settings cannot be parsed or if the request refers
-// to a model without a corresponding deployment in settings. It then proxies the request
-// using the configured API key and deployment.
-type azureOpenAIProxy struct {
-	settings Settings
-	// rp is a reverse proxy handling the modified request. Use this rather than
-	// our own client, since it handles things like buffering.
-	rp *httputil.ReverseProxy
-}
-
-func (a *azureOpenAIProxy) modifyRequest(req *http.Request) error {
-	err := modifyURL(a.settings.OpenAI.URL, req)
-	if err != nil {
-		return fmt.Errorf("modify url: %w", err)
-	}
-
-	// Read the body so we can determine the deployment to use
-	// by mapping the model in the request to a deployment in settings.
-	// Azure OpenAI API requires this deployment name in the URL.
-	bodyBytes, _ := io.ReadAll(req.Body)
-	var requestBody map[string]interface{}
-	err = json.Unmarshal(bodyBytes, &requestBody)
-	if err != nil {
-		return fmt.Errorf("unmarshal request body: %w", err)
-	}
-
-	// Find the deployment for the model.
-	// Models are mapped to deployments in settings.OpenAI.AzureMapping.
-	var deployment string = ""
-	for _, v := range a.settings.OpenAI.AzureMapping {
-		if val, ok := requestBody["model"].(string); ok && val == v[0] {
-			deployment = v[1]
-			break
-		}
-	}
-
-	if deployment == "" {
-		return fmt.Errorf("no deployment found for model: %s", requestBody["model"])
-	}
-
-	// We've got a deployment, so finish modifying the request.
-	req.URL.Path = fmt.Sprintf("/openai/deployments/%s/%s", deployment, strings.TrimPrefix(req.URL.Path, "/openai/v1/"))
-	req.Header.Add("api-key", a.settings.OpenAI.apiKey)
-	req.URL.RawQuery = "api-version=2023-03-15-preview"
-
-	// Remove extra fields
-	delete(requestBody, "model")
-
-	newBodyBytes, err := json.Marshal(requestBody)
-	if err != nil {
-		return fmt.Errorf("unmarshal request body: %w", err)
-	}
-	req.Body = io.NopCloser(bytes.NewBuffer(newBodyBytes))
-	req.ContentLength = int64(len(newBodyBytes))
-	return nil
-}
-
-func (a *azureOpenAIProxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	err := a.modifyRequest(req)
-	if err != nil {
-		// Attempt to write the error as JSON.
-		jd, err := json.Marshal(map[string]string{"error": err.Error()})
-		if err != nil {
-			// We can't write JSON, so just write the error string.
-			w.WriteHeader(http.StatusInternalServerError)
-			_, err = w.Write([]byte(err.Error()))
-			if err != nil {
-				log.DefaultLogger.Error("Unable to write error response", "err", err)
-			}
-			return
-		}
-		w.WriteHeader(http.StatusBadRequest)
-		_, err = w.Write(jd)
-		if err != nil {
-			log.DefaultLogger.Error("Unable to write error response", "err", err)
-		}
-		return
-	}
-	a.rp.ServeHTTP(w, req)
-}
-
-func newAzureOpenAIProxy(settings Settings) http.Handler {
-	// We make all of the actual modifications in ServeHTTP, since they can fail
-	// and we want to early-return from HTTP requests in that case.
-	director := func(req *http.Request) {}
-	return &azureOpenAIProxy{
-		settings: settings,
-		rp: &httputil.ReverseProxy{
-			Director: director,
-		},
-	}
-}
-
-// grafanaOpenAIProxy is a reverse proxy for OpenAI API calls, that proxies all
-// requests via the llm-gateway.
-type grafanaOpenAIProxy struct {
-	settings Settings
-	// rp is a reverse proxy handling the modified request. Use this rather than
-	// our own client, since it handles things like buffering.
-	rp *httputil.ReverseProxy
-}
-
-func (a *grafanaOpenAIProxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	err := modifyURL(a.settings.LLMGateway.URL, req)
-	if err != nil {
-		// Attempt to write the error as JSON.
-		jd, err := json.Marshal(map[string]string{"error": err.Error()})
-		if err != nil {
-			// We can't write JSON, so just write the error string.
-			w.WriteHeader(http.StatusInternalServerError)
-			_, err = w.Write([]byte(err.Error()))
-			if err != nil {
-				log.DefaultLogger.Error("Unable to write error response", "err", err)
-			}
-			return
-		}
-		w.WriteHeader(http.StatusBadRequest)
-		_, err = w.Write(jd)
-		if err != nil {
-			log.DefaultLogger.Error("Unable to write error response", "err", err)
-		}
-	}
-	a.rp.ServeHTTP(w, req)
-}
-
-func newGrafanaOpenAIProxy(settings Settings) http.Handler {
-	director := func(req *http.Request) {
-		req.SetBasicAuth(settings.Tenant, settings.GrafanaComAPIKey)
-		req.Header.Add("X-Scope-OrgID", settings.Tenant)
-	}
-
-	return &grafanaOpenAIProxy{
-		settings: settings,
-		rp:       &httputil.ReverseProxy{Director: director},
-	}
 }
 
 type vectorSearchRequest struct {
@@ -635,18 +448,78 @@ func doRequest(req *http.Request) ([]byte, error) {
 	return respBody, nil
 }
 
-// registerRoutes takes a *http.ServeMux and registers some HTTP handlers.
-func (a *App) registerRoutes(mux *http.ServeMux, settings Settings) {
-	switch settings.OpenAI.Provider {
-	case openAIProviderOpenAI:
-		mux.Handle("/openai/", newOpenAIProxy(settings))
-	case openAIProviderAzure:
-		mux.Handle("/openai/", newAzureOpenAIProxy(settings))
-	case openAIProviderGrafana:
-		mux.Handle("/openai/", newGrafanaOpenAIProxy(settings))
-	default:
-		log.DefaultLogger.Warn("Unknown OpenAI provider configured", "provider", settings.OpenAI.Provider)
+func (a *App) handleModels(llmProvider LLMProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if llmProvider == nil {
+			handleError(w, errors.New("must configure an LLM provider"), http.StatusUnprocessableEntity)
+			return
+		}
+		if r.Method != http.MethodGet {
+			handleError(w, errors.New("only GET method allowed"), http.StatusMethodNotAllowed)
+			return
+		}
+		models, err := llmProvider.Models(r.Context())
+		if errors.Is(err, errBadRequest) {
+			handleError(w, err, http.StatusBadRequest)
+		} else if err != nil {
+			handleError(w, err, http.StatusInternalServerError)
+			return
+		}
+
+		resp, err := json.Marshal(models)
+		if err != nil {
+			handleError(w, err, http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(resp)
 	}
+}
+
+func (a *App) handleChatCompletions(llmProvider LLMProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if llmProvider == nil {
+			handleError(w, errors.New("must configure an LLM provider"), http.StatusUnprocessableEntity)
+			return
+		}
+		if r.Method != http.MethodPost {
+			handleError(w, errors.New("only POST method allowed"), http.StatusMethodNotAllowed)
+			return
+		}
+		reqBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			handleError(w, err, http.StatusInternalServerError)
+			return
+		}
+		req := ChatCompletionRequest{}
+		err = json.Unmarshal(reqBody, &req)
+		if err != nil {
+			handleError(w, fmt.Errorf("could not decode request: %w", err), http.StatusBadRequest)
+			return
+		}
+
+		resp, err := llmProvider.ChatCompletions(r.Context(), req)
+		if errors.Is(err, errBadRequest) {
+			handleError(w, err, http.StatusBadRequest)
+		} else if err != nil {
+			handleError(w, err, http.StatusInternalServerError)
+			return
+		}
+
+		respBody, err := json.Marshal(resp)
+		if err != nil {
+			handleError(w, err, http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(respBody)
+	}
+}
+
+// registerRoutes takes a *http.ServeMux and registers some HTTP handlers.
+func (a *App) registerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/openai/v1/models", a.handleModels(a.llmProvider))
+	mux.HandleFunc("/openai/v1/chat/completions", a.handleChatCompletions(a.llmProvider))
 	mux.HandleFunc("/vector/search", a.handleVectorSearch)
 	mux.HandleFunc("/grafana-llm-state", a.handleLLMState)
 	mux.HandleFunc("/save-plugin-settings", a.handleSavePluginSettings)

--- a/packages/grafana-llm-app/pkg/plugin/resources_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/resources_test.go
@@ -171,6 +171,7 @@ func newMockOpenAIServer(t *testing.T) *mockServer {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		server.request = r
 		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
 	})
 	server.server = httptest.NewServer(handler)
 	return server
@@ -211,14 +212,14 @@ func TestCallOpenAIProxy(t *testing.T) {
 
 			method: http.MethodPost,
 			path:   "/openai/v1/chat/completions",
-			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
+			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": [{"content":"some stuff"}]}`),
 
 			expReqHeaders: http.Header{
 				"Authorization":       {"Bearer abcd1234"},
 				"OpenAI-Organization": {"myOrg"},
 			},
 			expReqPath: "/v1/chat/completions",
-			expReqBody: []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
+			expReqBody: []byte(`{"model": "gpt-3.5-turbo", "messages": [{"content":"some stuff"}]}`),
 
 			expStatus: http.StatusOK,
 		},
@@ -239,14 +240,14 @@ func TestCallOpenAIProxy(t *testing.T) {
 
 			method: http.MethodPost,
 			path:   "/openai/v1/chat/completions",
-			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
+			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": [{"content":"some stuff"}]}`),
 
 			expReqHeaders: http.Header{
 				"api-key": {"abcd1234"},
 			},
 			expReqPath: "/openai/deployments/gpt-35-turbo/chat/completions",
 			// the 'model' field should have been removed.
-			expReqBody: []byte(`{"messages":["some stuff"]}`),
+			expReqBody: []byte(`{"messages":[{"content":"some stuff"}]}`),
 
 			expStatus: http.StatusOK,
 		},
@@ -267,7 +268,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			method: http.MethodPost,
 			path:   "/openai/v1/chat/completions",
 			// note no gpt-4 in AzureMapping.
-			body: []byte(`{"model": "gpt-4", "messages": ["some stuff"]}`),
+			body: []byte(`{"model": "gpt-4", "messages": [{"content":"some stuff"}]}`),
 
 			expNilRequest: true,
 
@@ -287,14 +288,14 @@ func TestCallOpenAIProxy(t *testing.T) {
 
 			method: http.MethodPost,
 			path:   "/openai/v1/chat/completions",
-			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
+			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": [{"content":"some stuff"}]}`),
 
 			expReqHeaders: http.Header{
 				"Authorization": {"Basic MTIzOmFiY2QxMjM0"},
 				"X-Scope-OrgID": {"123"},
 			},
 			expReqPath: "/llm/openai/v1/chat/completions",
-			expReqBody: []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
+			expReqBody: []byte(`{"model": "gpt-3.5-turbo", "messages": [{"content":"some stuff"}]}`),
 
 			expStatus: http.StatusOK,
 		},
@@ -312,14 +313,14 @@ func TestCallOpenAIProxy(t *testing.T) {
 
 			method: http.MethodPost,
 			path:   "/openai/v1/chat/completions",
-			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
+			body:   []byte(`{"model": "gpt-3.5-turbo", "messages": [{"content":"some stuff"}]}`),
 
 			expReqHeaders: http.Header{
 				"Authorization": {"Basic MTIzOmFiY2QxMjM0"},
 				"X-Scope-OrgID": {"123"},
 			},
 			expReqPath: "/llm/openai/v1/chat/completions",
-			expReqBody: []byte(`{"model": "gpt-3.5-turbo", "messages": ["some stuff"]}`),
+			expReqBody: []byte(`{"model": "gpt-3.5-turbo", "messages": [{"content":"some stuff"]}}`),
 
 			expStatus: http.StatusOK,
 		},

--- a/packages/grafana-llm-app/src/components/AppConfig/DevSandbox.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/DevSandbox.tsx
@@ -37,7 +37,7 @@ const BasicChatTest = () => {
     if (!useStream) {
       // Make a single request to the LLM.
       const response = await openai.chatCompletions({
-        model: 'gpt-3.5-turbo',
+        model: 'small',
         messages: [
           { role: 'system', content: 'You are a cynical assistant.' },
           { role: 'user', content: message },


### PR DESCRIPTION
Rather than having the client pass in OpenAI specific models create an abstraction for a default and a high accuracy model. For backwards compatability gpt-3.5-turbo is mapped to default and gpt-4 is mapped to high accuracy.

As part of this it is also required to read the body in order to transform from an abstracted model to the specific model (or deployment in the case of Azure) being used. A simple interface is used that currently only supports Models and ChatCompletions, but can be expanded to support StreamChatCompletions in the future (and refactor the streaming code). This also means we now limit the endpoints that our API allows to just be Models and ChatCompletions as well. These are all that we have really seen used so it should be ok.

I have also avoided updating the frontend to use these new model names to make sure that this is truly backwards compatible. We can update the frontend in a future PR after this has been tested and merged. Ideally deployed as well as a frontend updating before a backend could cause breakages.