### PR TITLE
Update SA token retrieval logic

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/app.go
+++ b/packages/grafana-llm-app/pkg/plugin/app.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -71,7 +72,12 @@ func NewApp(ctx context.Context, appSettings backend.AppInstanceSettings) (insta
 	app.CallResourceHandler = httpadapter.New(mux)
 
 	// Getting the service account token that has been shared with the plugin
-	app.saToken = os.Getenv("GF_PLUGIN_APP_CLIENT_SECRET")
+	cfg := backend.GrafanaConfigFromContext(ctx)
+	app.saToken, err = cfg.PluginAppClientSecret()
+	if err != nil {
+		log.DefaultLogger.Error("Error getting service account token")
+		return nil, fmt.Errorf("error getting service account token: %w", err)
+	}
 
 	// The Grafana URL is required to request Grafana API later
 	app.grafanaAppURL = strings.TrimRight(os.Getenv("GF_APP_URL"), "/")

--- a/packages/grafana-llm-app/pkg/plugin/app.go
+++ b/packages/grafana-llm-app/pkg/plugin/app.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -75,8 +74,7 @@ func NewApp(ctx context.Context, appSettings backend.AppInstanceSettings) (insta
 	cfg := backend.GrafanaConfigFromContext(ctx)
 	app.saToken, err = cfg.PluginAppClientSecret()
 	if err != nil {
-		log.DefaultLogger.Error("Error getting service account token")
-		return nil, fmt.Errorf("error getting service account token: %w", err)
+		log.DefaultLogger.Warn("Unable to get service account token", "err", err)
 	}
 
 	// The Grafana URL is required to request Grafana API later


### PR DESCRIPTION
Grafana external service account tokens should be retrieved via the plugin sdk.