### PR TITLE
docker: grafana_version use mainline

### DIFF
--- a/packages/grafana-llm-app/docker-compose.yaml
+++ b/packages/grafana-llm-app/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     build:
       context: ./.config
       args:
-        grafana_version: ${GRAFANA_VERSION:-10.3.0}
+        grafana_version: ${GRAFANA_VERSION:-main}
     environment:
       AZURE_OPENAI_API_KEY: $AZURE_OPENAI_API_KEY
       GF_LOG_LEVEL: debug


### PR DESCRIPTION
bumps to 11 (which has dashgpt features to try out)
