### PR TITLE
testing: add configurable test provider for use in integration tests

### DIFF
--- a/packages/grafana-llm-app/docker-compose.yaml
+++ b/packages/grafana-llm-app/docker-compose.yaml
@@ -25,6 +25,8 @@ services:
       - ./provisioning/plugins/grafana-vector-api/:/etc/grafana/provisioning/plugins/
       # For openai embedder and qdrant store
       # - ./provisioning/plugins/openai-qdrant/:/etc/grafana/provisioning/plugins/
+      # For test provider, no store
+      # - ./provisioning/plugins/test-provider/:/etc/grafana/provisioning/plugins/
 
   # For openai embedder and qdrant store
   # qdrant:

--- a/packages/grafana-llm-app/pkg/plugin/app.go
+++ b/packages/grafana-llm-app/pkg/plugin/app.go
@@ -82,7 +82,7 @@ func NewApp(ctx context.Context, appSettings backend.AppInstanceSettings) (insta
 		}
 		app.llmProvider = p
 	case openAIProviderTest:
-		app.llmProvider = &app.settings.TestProvider
+		app.llmProvider = &app.settings.OpenAI.TestProvider
 	}
 
 	// Use a httpadapter (provided by the SDK) for resource calls. This allows us

--- a/packages/grafana-llm-app/pkg/plugin/app.go
+++ b/packages/grafana-llm-app/pkg/plugin/app.go
@@ -81,6 +81,8 @@ func NewApp(ctx context.Context, appSettings backend.AppInstanceSettings) (insta
 			return nil, err
 		}
 		app.llmProvider = p
+	case openAIProviderTest:
+		app.llmProvider = &app.settings.TestProvider
 	}
 
 	// Use a httpadapter (provided by the SDK) for resource calls. This allows us

--- a/packages/grafana-llm-app/pkg/plugin/settings.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings.go
@@ -21,6 +21,7 @@ const (
 	openAIProviderOpenAI  openAIProvider = "openai"
 	openAIProviderAzure   openAIProvider = "azure"
 	openAIProviderGrafana openAIProvider = "grafana" // via llm-gateway
+	openAIProviderTest    openAIProvider = "test"
 )
 
 // OpenAISettings contains the user-specified OpenAI connection details
@@ -122,6 +123,9 @@ type Settings struct {
 
 	EnableGrafanaManagedLLM bool `json:"enableGrafanaManagedLLM"`
 
+	// TestProvider contains the settings for the test provider.
+	TestProvider testProvider `json:"testProvider,omitempty"`
+
 	// OpenAI related settings
 	OpenAI OpenAISettings `json:"openAI"`
 
@@ -136,7 +140,7 @@ type Settings struct {
 }
 
 func loadSettings(appSettings backend.AppInstanceSettings) (*Settings, error) {
-	settings := Settings{}
+	settings := Settings{TestProvider: defaultTestProvider()}
 
 	if len(appSettings.JSONData) != 0 {
 		err := json.Unmarshal(appSettings.JSONData, &settings)
@@ -172,6 +176,8 @@ func loadSettings(appSettings backend.AppInstanceSettings) (*Settings, error) {
 			log.DefaultLogger.Warn("Cannot use LLM Gateway as no URL specified, disabling it")
 			settings.OpenAI.Provider = ""
 		}
+	case openAIProviderTest:
+		settings.OpenAI.Provider = openAIProviderTest
 	default:
 		// Default to disabled LLM support if an unknown provider was specified.
 		log.DefaultLogger.Warn("Unknown OpenAI provider", "provider", settings.OpenAI.Provider)

--- a/packages/grafana-llm-app/pkg/plugin/settings.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings.go
@@ -59,6 +59,8 @@ func (s OpenAISettings) Configured() bool {
 	switch s.Provider {
 	case openAIProviderGrafana:
 		return true
+	case openAIProviderTest:
+		return true
 	case openAIProviderAzure:
 		// Require some mappings for use with Azure.
 		if len(s.AzureMapping) == 0 {

--- a/packages/grafana-llm-app/pkg/plugin/settings.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings.go
@@ -44,6 +44,10 @@ type OpenAISettings struct {
 	// apiKey is the user-specified  api key needed to authenticate requests to the OpenAI
 	// provider (excluding the LLMGateway). Stored securely.
 	apiKey string
+
+	// TestProvider contains the settings for the test provider.
+	// Only used when Provider is openAIProviderTest.
+	TestProvider testProvider `json:"testProvider,omitempty"`
 }
 
 func (s OpenAISettings) Configured() bool {
@@ -123,9 +127,6 @@ type Settings struct {
 
 	EnableGrafanaManagedLLM bool `json:"enableGrafanaManagedLLM"`
 
-	// TestProvider contains the settings for the test provider.
-	TestProvider testProvider `json:"testProvider,omitempty"`
-
 	// OpenAI related settings
 	OpenAI OpenAISettings `json:"openAI"`
 
@@ -140,7 +141,7 @@ type Settings struct {
 }
 
 func loadSettings(appSettings backend.AppInstanceSettings) (*Settings, error) {
-	settings := Settings{TestProvider: defaultTestProvider()}
+	settings := Settings{OpenAI: OpenAISettings{TestProvider: defaultTestProvider()}}
 
 	if len(appSettings.JSONData) != 0 {
 		err := json.Unmarshal(appSettings.JSONData, &settings)

--- a/packages/grafana-llm-app/pkg/plugin/test_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/test_provider.go
@@ -40,8 +40,8 @@ func defaultTestProvider() testProvider {
 	return testProvider{
 		ModelsResponse: ModelResponse{
 			Data: []ModelInfo{
-				{ID: "tiny"},
-				{ID: "enormous"},
+				{ID: "base"},
+				{ID: "large"},
 			},
 		},
 

--- a/packages/grafana-llm-app/pkg/plugin/test_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/test_provider.go
@@ -1,0 +1,120 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// Ensure that testProvider implements the LLMProvider interface.
+var _ LLMProvider = (*testProvider)(nil)
+
+// testProvider is a test implementation of LLMProvider.
+type testProvider struct {
+	// ModelsResponse is the response to return from Models.
+	ModelsResponse ModelResponse `json:"modelsResponse,omitempty"`
+
+	// ChatCompletionResponse is the response to return from ChatCompletion.
+	ChatCompletionResponse ChatCompletionResponse `json:"chatCompletionResponse,omitempty"`
+
+	// ChatCompletionError is an error to return from ChatCompletion.
+	// If nil (the default) ChatCompletion will not return an error.
+	ChatCompletionError string `json:"chatCompletionError,omitempty"`
+
+	// InitialStreamError is an error to return from ChatCompletionStream.
+	// If nil (the default) ChatCompletionStream will not return an error.
+	InitialStreamError string `json:"initialStreamError,omitempty"`
+
+	// StreamDeltas is a list of StreamDeltas to return from ChatCompletionStream.
+	StreamDeltas []openai.ChatCompletionStreamChoiceDelta `json:"streamDeltas,omitempty"`
+	// StreamFinishReason is the reason to finish the stream.
+	// Defaults to FinishReasonStop.
+	StreamFinishReason openai.FinishReason `json:"streamFinishReason,omitempty"`
+	// StreamError is an error to return from ChatCompletionStream after the first delta.
+	// If nil (the default) the stream will finish with a stop reason.
+	StreamError string `json:"streamError,omitempty"`
+}
+
+func defaultTestProvider() testProvider {
+	return testProvider{
+		ModelsResponse: ModelResponse{
+			Data: []ModelInfo{
+				{ID: "tiny"},
+				{ID: "enormous"},
+			},
+		},
+
+		ChatCompletionResponse: ChatCompletionResponse{
+			ID:    "0",
+			Model: "tiny",
+			Usage: Usage{
+				TotalTokens:      10,
+				PromptTokens:     5,
+				CompletionTokens: 5,
+			},
+		},
+		ChatCompletionError: "",
+
+		InitialStreamError: "",
+		StreamDeltas: []openai.ChatCompletionStreamChoiceDelta{
+			{Content: "Hello ", Role: openai.ChatMessageRoleAssistant},
+			{Content: "there", Role: openai.ChatMessageRoleAssistant},
+			{Content: ".", Role: openai.ChatMessageRoleAssistant},
+		},
+		StreamFinishReason: openai.FinishReasonStop,
+		StreamError:        "",
+	}
+}
+
+func (p *testProvider) Models(context.Context) (ModelResponse, error) {
+	return p.ModelsResponse, nil
+}
+
+func (p *testProvider) ChatCompletion(ctx context.Context, req ChatCompletionRequest) (ChatCompletionResponse, error) {
+	if p.ChatCompletionError != "" {
+		return ChatCompletionResponse{}, errors.New(p.ChatCompletionError)
+	}
+	return p.ChatCompletionResponse, nil
+}
+
+func (p *testProvider) ChatCompletionStream(ctx context.Context, req ChatCompletionRequest) (<-chan ChatCompletionStreamResponse, error) {
+	if p.InitialStreamError != "" {
+		return nil, errors.New(p.InitialStreamError)
+	}
+	// Use a buffered channel to avoid blocking or requiring a separate goroutine.
+	// The buffer size is the number of deltas plus one for the stop reason.
+	c := make(chan ChatCompletionStreamResponse, len(p.StreamDeltas)+1)
+	defer close(c)
+	i := 0
+	for _, d := range p.StreamDeltas {
+
+		if i == 1 && p.StreamError != "" {
+			c <- ChatCompletionStreamResponse{Error: errors.New(p.StreamError)}
+			break
+		}
+
+		c <- ChatCompletionStreamResponse{
+			ChatCompletionStreamResponse: openai.ChatCompletionStreamResponse{
+				Choices: []openai.ChatCompletionStreamChoice{
+					{Delta: d},
+				},
+			},
+		}
+		i += 1
+	}
+
+	// Finish with a stop reason.
+	finishReason := openai.FinishReasonStop
+	if p.StreamFinishReason != "" {
+		finishReason = p.StreamFinishReason
+	}
+	c <- ChatCompletionStreamResponse{
+		ChatCompletionStreamResponse: openai.ChatCompletionStreamResponse{
+			Choices: []openai.ChatCompletionStreamChoice{
+				{FinishReason: finishReason},
+			},
+		},
+	}
+	return c, nil
+}

--- a/packages/grafana-llm-app/pkg/plugin/test_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/test_provider.go
@@ -71,14 +71,35 @@ func (p *testProvider) Models(context.Context) (ModelResponse, error) {
 	return p.ModelsResponse, nil
 }
 
+func validateChatCompletionRequest(req ChatCompletionRequest) error {
+	if len(req.ChatCompletionRequest.Messages) == 0 {
+		return errors.New("at least one message is required")
+	}
+	for _, m := range req.ChatCompletionRequest.Messages {
+		if m.Role == "" {
+			return errors.New("role is required for each message")
+		}
+		if m.Content == "" {
+			return errors.New("content is required for each message")
+		}
+	}
+	return nil
+}
+
 func (p *testProvider) ChatCompletion(ctx context.Context, req ChatCompletionRequest) (ChatCompletionResponse, error) {
 	if p.ChatCompletionError != "" {
 		return ChatCompletionResponse{}, errors.New(p.ChatCompletionError)
+	}
+	if err := validateChatCompletionRequest(req); err != nil {
+		return ChatCompletionResponse{}, err
 	}
 	return p.ChatCompletionResponse, nil
 }
 
 func (p *testProvider) ChatCompletionStream(ctx context.Context, req ChatCompletionRequest) (<-chan ChatCompletionStreamResponse, error) {
+	if err := validateChatCompletionRequest(req); err != nil {
+		return nil, err
+	}
 	if p.InitialStreamError != "" {
 		return nil, errors.New(p.InitialStreamError)
 	}

--- a/packages/grafana-llm-app/pkg/plugin/test_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/test_provider.go
@@ -16,7 +16,7 @@ type testProvider struct {
 	ModelsResponse ModelResponse `json:"modelsResponse,omitempty"`
 
 	// ChatCompletionResponse is the response to return from ChatCompletion.
-	ChatCompletionResponse ChatCompletionResponse `json:"chatCompletionResponse,omitempty"`
+	ChatCompletionResponse openai.ChatCompletionResponse `json:"chatCompletionResponse,omitempty"`
 
 	// ChatCompletionError is an error to return from ChatCompletion.
 	// If nil (the default) ChatCompletion will not return an error.
@@ -45,10 +45,10 @@ func defaultTestProvider() testProvider {
 			},
 		},
 
-		ChatCompletionResponse: ChatCompletionResponse{
+		ChatCompletionResponse: openai.ChatCompletionResponse{
 			ID:    "0",
 			Model: "tiny",
-			Usage: Usage{
+			Usage: openai.Usage{
 				TotalTokens:      10,
 				PromptTokens:     5,
 				CompletionTokens: 5,
@@ -86,12 +86,12 @@ func validateChatCompletionRequest(req ChatCompletionRequest) error {
 	return nil
 }
 
-func (p *testProvider) ChatCompletion(ctx context.Context, req ChatCompletionRequest) (ChatCompletionResponse, error) {
+func (p *testProvider) ChatCompletion(ctx context.Context, req ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
 	if p.ChatCompletionError != "" {
-		return ChatCompletionResponse{}, errors.New(p.ChatCompletionError)
+		return openai.ChatCompletionResponse{}, errors.New(p.ChatCompletionError)
 	}
 	if err := validateChatCompletionRequest(req); err != nil {
-		return ChatCompletionResponse{}, err
+		return openai.ChatCompletionResponse{}, err
 	}
 	return p.ChatCompletionResponse, nil
 }

--- a/packages/grafana-llm-app/provisioning/plugins/test-provider/grafana-llm-app.yaml
+++ b/packages/grafana-llm-app/provisioning/plugins/test-provider/grafana-llm-app.yaml
@@ -1,0 +1,74 @@
+apiVersion: 1
+
+apps:
+  - type: grafana-llm-app
+    jsonData:
+      base64EncodedAccessTokenSet: True
+      # enableGrafanaManagedLLM: True
+      # displayVectorStoreOptions: False
+      openAI:
+        provider: test
+        # url: https://api.openai.com
+        # organizationId: $OPENAI_ORGANIZATION_ID
+        testProvider:
+          modelsResponse: 
+            data:
+            - id: small
+            - id: medium
+            - id: large
+
+          chatCompletionResponse:
+            id: "1234"
+            model: "small"
+            choices:
+            - message:
+                role: "assistant"
+                content: "How are you today?"
+          chatCompletionError: ""
+
+          initialStreamError: ""
+          streamDeltas:
+            - role: "assistant"
+              content: "How "
+            - role: "assistant"
+              content: "are "
+            - role: "assistant"
+              content: "you "
+            - role: "assistant"
+              content: "today"
+            - role: "assistant"
+              content: "?"
+          streamFinishReason: "stop"
+          streamError: ""
+      # openAI:
+        # provider: azure
+        # url: https://<resource>.openai.azure.com
+        # azureModelMapping:
+        #   - ["gpt-3.5-turbo", "gpt-35-turbo"]
+      # vector:
+      #   enabled: true
+      #   model: BAAI/bge-small-en-v1.5
+      #   embed:
+      #     type: grafana/vectorapi
+      #     grafanaVectorAPI:
+      #       url: http://vectorapi:8889
+      #       authType: no-auth
+      #       # authType: basic-auth
+      #       # basicAuthUser: <user>
+      #   store:
+      #     type: grafana/vectorapi
+      #     grafanaVectorAPI:
+      #       url: http://vectorapi:8889
+      #       authType: no-auth
+      #       # authType: basic-auth
+      #       # basicAuthUser: <user>
+      # llmGateway:
+      #   url: http://llm-gateway:4033
+
+    secureJsonData:
+      # openAIKey: $OPENAI_API_KEY
+      # mock EncodedAccessToken "thestack:thetoken"
+      # base64EncodedAccessToken: dGhlc3RhY2s6dGhldG9rZW4=
+      # openAIKey: $AZURE_OPENAI_API_KEY
+      # vectorEmbedderBasicAuthPassword: $VECTOR_EMBEDDER_BASIC_AUTH_PASSWORD
+      # vectorStoreBasicAuthPassword: $VECTOR_STORE_BASIC_AUTH_PASSWORD

--- a/packages/grafana-llm-app/provisioning/plugins/test-provider/grafana-llm-app.yaml
+++ b/packages/grafana-llm-app/provisioning/plugins/test-provider/grafana-llm-app.yaml
@@ -13,13 +13,12 @@ apps:
         testProvider:
           modelsResponse: 
             data:
-            - id: small
-            - id: medium
+            - id: base
             - id: large
 
           chatCompletionResponse:
             id: "1234"
-            model: "small"
+            model: "base"
             choices:
             - message:
                 role: "assistant"
@@ -40,6 +39,7 @@ apps:
               content: "?"
           streamFinishReason: "stop"
           streamError: ""
+
       # vector:
       #   enabled: true
       #   model: BAAI/bge-small-en-v1.5

--- a/packages/grafana-llm-app/provisioning/plugins/test-provider/grafana-llm-app.yaml
+++ b/packages/grafana-llm-app/provisioning/plugins/test-provider/grafana-llm-app.yaml
@@ -40,11 +40,6 @@ apps:
               content: "?"
           streamFinishReason: "stop"
           streamError: ""
-      # openAI:
-        # provider: azure
-        # url: https://<resource>.openai.azure.com
-        # azureModelMapping:
-        #   - ["gpt-3.5-turbo", "gpt-35-turbo"]
       # vector:
       #   enabled: true
       #   model: BAAI/bge-small-en-v1.5

--- a/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
@@ -11,7 +11,7 @@ import { OpenAIConfig, OpenAIProvider } from './OpenAI';
 import { OpenAILogo } from './OpenAILogo';
 
 // LLMOptions are the 3 possible UI options for LLMs (grafana-provided cloud-only).
-export type LLMOptions = 'grafana-provided' | 'openai' | 'disabled' | 'unconfigured';
+export type LLMOptions = 'grafana-provided' | 'openai' | 'test' | 'disabled' | 'unconfigured';
 
 // This maps the current settings to decide what UI selection (LLMOptions) to show
 function getLLMOptionFromSettings(settings: AppPluginSettings): LLMOptions {
@@ -23,6 +23,8 @@ function getLLMOptionFromSettings(settings: AppPluginSettings): LLMOptions {
     case 'azure':
     case 'openai':
       return 'openai';
+    case 'test':
+      return 'test';
     case 'grafana':
       return 'grafana-provided';
     default:
@@ -69,9 +71,21 @@ export function LLMConfig({
         setPreviousOpenAIProvider(settings.openAI?.provider);
       }
 
-      onChange({ ...settings, openAI: { provider: undefined, disabled: true } });
+      onChange({ ...settings, openAI: { ...settings.openAI, provider: undefined, disabled: true } });
     }
   };
+
+  const selectLLMTest = () => {
+    if (llmOption !== 'test') {
+      // Cache if OpenAI or Azure provider is used, so can restore
+      if (previousOpenAIProvider === undefined) {
+        setPreviousOpenAIProvider(settings.openAI?.provider);
+      }
+
+      onChange({ ...settings, openAI: { ...settings.openAI, provider: 'test', disabled: false } });
+    }
+  };
+
 
   const selectGrafanaManaged = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
     if (llmOption !== 'grafana-provided') {
@@ -221,6 +235,14 @@ export function LLMConfig({
             </Card.Figure>
           </Card>
         </div>
+        {(llmOption === 'test' || previousOpenAIProvider === 'test') && (
+          <Card isSelected={llmOption === 'test'} className={s.cardWithoutBottomMargin} onClick={selectLLMTest}>
+            <Card.Heading>Test LLM features</Card.Heading>
+            <Card.Figure>
+              <Icon name="bug" size="lg" />
+            </Card.Figure>
+          </Card>
+        )}
         <Card isSelected={llmOption === 'disabled'} onClick={selectLLMDisabled} className={s.cardWithoutBottomMargin}>
           <Card.Heading>Disable all LLM features in Grafana</Card.Heading>
           <Card.Description>&nbsp;</Card.Description>

--- a/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
@@ -235,7 +235,7 @@ export function LLMConfig({
             </Card.Figure>
           </Card>
         </div>
-        {(llmOption === 'test' || previousOpenAIProvider === 'test') && (
+        {process.env.NODE_ENV === 'development' && (
           <Card isSelected={llmOption === 'test'} className={s.cardWithoutBottomMargin} onClick={selectLLMTest}>
             <Card.Heading>Test LLM features</Card.Heading>
             <Card.Figure>

--- a/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
@@ -8,7 +8,7 @@ import { testIds } from 'components/testIds';
 import { getStyles, Secrets, SecretsSet } from './AppConfig';
 import { AzureModelDeploymentConfig, AzureModelDeployments } from './AzureConfig';
 
-export type OpenAIProvider = 'openai' | 'azure' | 'grafana';
+export type OpenAIProvider = 'openai' | 'azure' | 'grafana' | 'test';
 
 export interface OpenAISettings {
   // The URL to reach OpenAI.


### PR DESCRIPTION
This adds a new LLMProvider which just returns some messages defined in the JSONData. It's configured by setting `settings.OpenAI.Provider` to "test". This will allow us to test the various other plugin aspects (resource calls, streaming calls) in a more realistic environment without having to configure OpenAI/Azure or run a separate LLM gateway.