### PR TITLE
model abstraction: S/M/L -> Base/Large

### DIFF
--- a/packages/grafana-llm-app/README.md
+++ b/packages/grafana-llm-app/README.md
@@ -73,7 +73,8 @@ apps:
         provider: azure
         url: https://<resource>.openai.azure.com
         azureModelMapping:
-          - ["gpt-3.5-turbo", "gpt-35-turbo"]
+          - ["base", "gpt-35-turbo"]
+          - ["large", "gpt-4-turbo"]
     secureJsonData:
       openAIKey: $OPENAI_API_KEY
 ```

--- a/packages/grafana-llm-app/llmclient/llmclient.go
+++ b/packages/grafana-llm-app/llmclient/llmclient.go
@@ -23,11 +23,9 @@ const (
 type Model string
 
 const (
-	// ModelSmall is the small model, which is the fastest and cheapest to use. OpenAI default: gpt-3.5-turbo
-	ModelSmall = "small"
-	// ModelMedium is the medium model, which is a good balance between speed and cost. OpenAI default: gpt-4-turbo
-	ModelMedium = "medium"
-	// ModelLarge is the large model, which is the most powerful and accurate. OpenAI default: gpt-4
+	// ModelBase is the base model, for efficient and high-throughput tasks. OpenAI default: gpt-3.5-turbo
+	ModelBase = "base"
+	// ModelLarge is the large model, for more advanced tasks with longer context windows. OpenAI default: gpt-4-turbo
 	ModelLarge = "large"
 )
 

--- a/packages/grafana-llm-app/llmclient/llmclient_test.go
+++ b/packages/grafana-llm-app/llmclient/llmclient_test.go
@@ -56,7 +56,7 @@ func TestChatCompletions(t *testing.T) {
 				{Role: "user", Content: "Hello, how are you?"},
 			},
 		},
-		Model: ModelSmall,
+		Model: ModelBase,
 	}
 	_, err := client.ChatCompletions(ctx, req)
 	if err != nil {
@@ -114,7 +114,7 @@ func TestChatCompletionsStream(t *testing.T) {
 			},
 			Stream: true,
 		},
-		Model: ModelSmall,
+		Model: ModelBase,
 	}
 	stream, err := client.ChatCompletionsStream(ctx, req)
 	if err != nil {

--- a/packages/grafana-llm-app/pkg/plugin/grafana_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/grafana_provider.go
@@ -51,8 +51,7 @@ func NewGrafanaProvider(settings Settings) (LLMProvider, error) {
 func (p *grafanaProvider) Models(ctx context.Context) (ModelResponse, error) {
 	return ModelResponse{
 		Data: []ModelInfo{
-			{ID: ModelSmall},
-			{ID: ModelMedium},
+			{ID: ModelBase},
 			{ID: ModelLarge},
 		},
 	}, nil

--- a/packages/grafana-llm-app/pkg/plugin/health.go
+++ b/packages/grafana-llm-app/pkg/plugin/health.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/build"
 )
 
-var openAIModels = []Model{ModelSmall, ModelMedium}
+var openAIModels = []Model{ModelBase, ModelLarge}
 
 type healthCheckClient interface {
 	Do(req *http.Request) (*http.Response, error)

--- a/packages/grafana-llm-app/pkg/plugin/health_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/health_test.go
@@ -77,7 +77,7 @@ func TestCheckHealth(t *testing.T) {
 			hcClient: &mockHealthCheckClient{
 				do: func(req *http.Request) (*http.Response, error) {
 					body, _ := io.ReadAll(req.Body)
-					if strings.Contains(string(body), "gpt-4") {
+					if strings.Contains(string(body), "gpt-4-turbo") {
 						body := io.NopCloser(strings.NewReader(`{"error": "model does not exist"}`))
 						return &http.Response{StatusCode: http.StatusNotFound, Body: body}, nil
 					}
@@ -89,8 +89,8 @@ func TestCheckHealth(t *testing.T) {
 					Configured: true,
 					OK:         true,
 					Models: map[Model]openAIModelHealth{
-						ModelSmall:  {OK: true, Error: ""},
-						ModelMedium: {OK: false, Error: `unexpected status code: 404: {"error": "model does not exist"}`},
+						ModelBase:  {OK: true, Error: ""},
+						ModelLarge: {OK: false, Error: `unexpected status code: 404: {"error": "model does not exist"}`},
 					},
 				},
 				Vector:  vectorHealthDetails{},
@@ -158,7 +158,7 @@ func TestCheckHealth(t *testing.T) {
 			hcClient: &mockHealthCheckClient{
 				do: func(req *http.Request) (*http.Response, error) {
 					body, _ := io.ReadAll(req.Body)
-					if strings.Contains(string(body), "gpt-4") {
+					if strings.Contains(string(body), "gpt-4-turbo") {
 						body := io.NopCloser(strings.NewReader(`{"error": "model does not exist"}`))
 						return &http.Response{StatusCode: http.StatusNotFound, Body: body}, nil
 					}
@@ -171,8 +171,8 @@ func TestCheckHealth(t *testing.T) {
 					OK:         true,
 					Error:      "",
 					Models: map[Model]openAIModelHealth{
-						ModelSmall:  {OK: true, Error: ""},
-						ModelMedium: {OK: false, Error: `unexpected status code: 404: {"error": "model does not exist"}`},
+						ModelBase:  {OK: true, Error: ""},
+						ModelLarge: {OK: false, Error: `unexpected status code: 404: {"error": "model does not exist"}`},
 					},
 				},
 				Vector: vectorHealthDetails{

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider_test.go
@@ -14,13 +14,8 @@ func TestModelFromString(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			input:    "small",
-			expected: ModelSmall,
-			wantErr:  false,
-		},
-		{
-			input:    "medium",
-			expected: ModelMedium,
+			input:    "base",
+			expected: ModelBase,
 			wantErr:  false,
 		},
 		{
@@ -44,22 +39,22 @@ func TestModelFromString(t *testing.T) {
 		// backwards-compatibility
 		{
 			input:    "gpt-3.5-turbo",
-			expected: ModelSmall,
+			expected: ModelBase,
 			wantErr:  false,
 		},
 		{
 			input:    "gpt-3.5-turbo-0125",
-			expected: ModelSmall,
+			expected: ModelBase,
 			wantErr:  false,
 		},
 		{
 			input:    "gpt-4-turbo",
-			expected: ModelMedium,
+			expected: ModelLarge,
 			wantErr:  false,
 		},
 		{
 			input:    "gpt-4-turbo-2024-04-09",
-			expected: ModelMedium,
+			expected: ModelLarge,
 			wantErr:  false,
 		},
 		{
@@ -95,13 +90,8 @@ func TestUnmarshalJSON(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			input:    []byte(`"small"`),
-			expected: ModelSmall,
-			wantErr:  false,
-		},
-		{
-			input:    []byte(`"medium"`),
-			expected: ModelMedium,
+			input:    []byte(`"base"`),
+			expected: ModelBase,
 			wantErr:  false,
 		},
 		{
@@ -130,22 +120,22 @@ func TestUnmarshalJSON(t *testing.T) {
 		// backwards-compatibility
 		{
 			input:    []byte(`"gpt-3.5-turbo"`),
-			expected: ModelSmall,
+			expected: ModelBase,
 			wantErr:  false,
 		},
 		{
 			input:    []byte(`"gpt-3.5-turbo-0125"`),
-			expected: ModelSmall,
+			expected: ModelBase,
 			wantErr:  false,
 		},
 		{
 			input:    []byte(`"gpt-4-turbo"`),
-			expected: ModelMedium,
+			expected: ModelLarge,
 			wantErr:  false,
 		},
 		{
 			input:    []byte(`"gpt-4-turbo-2024-04-09"`),
-			expected: ModelMedium,
+			expected: ModelLarge,
 			wantErr:  false,
 		},
 		{

--- a/packages/grafana-llm-app/pkg/plugin/openai_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/openai_provider.go
@@ -39,8 +39,7 @@ func NewOpenAIProvider(settings OpenAISettings) (LLMProvider, error) {
 func (p *openAI) Models(ctx context.Context) (ModelResponse, error) {
 	return ModelResponse{
 		Data: []ModelInfo{
-			{ID: ModelSmall},
-			{ID: ModelMedium},
+			{ID: ModelBase},
 			{ID: ModelLarge},
 		},
 	}, nil

--- a/packages/grafana-llm-app/pkg/plugin/resources_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/resources_test.go
@@ -250,7 +250,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 
 			method: http.MethodPost,
 			path:   "/openai/v1/chat/completions",
-			body:   []byte(`{"model": "small", "stream": true, "messages": [{"content":"some stuff"}]}`),
+			body:   []byte(`{"model": "base", "stream": true, "messages": [{"content":"some stuff"}]}`),
 
 			expReqHeaders: http.Header{
 				"Authorization":       {"Bearer abcd1234"},

--- a/packages/grafana-llm-app/provisioning/plugins/grafana-vector-api/grafana-llm-app.yaml
+++ b/packages/grafana-llm-app/provisioning/plugins/grafana-vector-api/grafana-llm-app.yaml
@@ -14,7 +14,8 @@ apps:
         # provider: azure
         # url: https://<resource>.openai.azure.com
         # azureModelMapping:
-        #   - ["gpt-3.5-turbo", "gpt-35-turbo"]
+        #   - ["base", "gpt-35-turbo"]
+        #   - ["large", "gpt-4-turbo"]
       vector:
         enabled: true
         model: BAAI/bge-small-en-v1.5

--- a/packages/grafana-llm-app/src/components/AppConfig/DevSandbox.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/DevSandbox.tsx
@@ -37,7 +37,7 @@ const BasicChatTest = () => {
     if (!useStream) {
       // Make a single request to the LLM.
       const response = await openai.chatCompletions({
-        model: 'small',
+        model: 'base',
         messages: [
           { role: 'system', content: 'You are a cynical assistant.' },
           { role: 'user', content: message },
@@ -50,7 +50,7 @@ const BasicChatTest = () => {
     } else {
       // Stream the completions. Each element is the next stream chunk.
       const stream = openai.streamChatCompletions({
-        model: 'gpt-3.5-turbo',
+        model: 'base',
         messages: [
           { role: 'system', content: 'You are a cynical assistant.' },
           { role: 'user', content: message },


### PR DESCRIPTION
Better naming + simpler is better
Diff between medium and large isn't clear for devs, and small would lead devs to maybe not use (and steer towards middle). Instead use Base/Large, so it's clear most use cases should try to use Base (or not define a model abstraction at all), and only use Large when you need that large context / more advanced capabilities.

This is breaking if any use cases already switched to small/medium before, but not handling those because
- 0.9.x was just released and was mostly a backend thing
- we'll handle fallback to default when we expose the frontend settings (so this will go into 0.10.x)

Split out from https://github.com/grafana/grafana-llm-app/pull/331 to make that PR smaller