### PR TITLE
Remove preload: true from plugin.json

### DIFF
--- a/packages/grafana-llm-app/src/plugin.json
+++ b/packages/grafana-llm-app/src/plugin.json
@@ -6,10 +6,14 @@
   "backend": true,
   "streaming": true,
   "executable": "gpx_llm",
-  "preload": true,
   "info": {
     "keywords": [
-      "app", "generative", "AI", "LLM", "OpenAI", "assistant"
+      "app",
+      "generative",
+      "AI",
+      "LLM",
+      "OpenAI",
+      "assistant"
     ],
     "description": "Plugin to easily allow LLM based extensions to grafana",
     "author": {


### PR DESCRIPTION
This causes Grafana to preload the plugin code whenever it starts
up rather than when the plugin is accessed, which slows startup
times. We don't need it since we don't offer any plugin extensions
or anything that requires the frontend to be loaded.

Note that this doesn't affect the availability of the backend, which
is always available.
