### PR TITLE
Expose model abstraction in frontend

### DIFF
--- a/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
@@ -7,16 +7,17 @@ import { FetchResponse, HealthCheckResult, getBackendSrv } from '@grafana/runtim
 import { Alert, Button, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 
 import { testIds } from '../testIds';
+import { ModelSettings } from './ModelConfig';
 import { ShowHealthCheckResult } from './HealthCheck';
 import { LLMConfig } from './LLMConfig';
 import { OpenAISettings } from './OpenAI';
 import { VectorConfig, VectorSettings } from './Vector';
-
 ///////////////////////
 
 export interface AppPluginSettings {
   openAI?: OpenAISettings;
   vector?: VectorSettings;
+  models?: ModelSettings;
   // The enableGrafanaManagedLLM flag will enable the plugin to use Grafana-managed OpenAI
   // This will only work for Grafana Cloud install plugins
   enableGrafanaManagedLLM?: boolean;
@@ -165,7 +166,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
           setUpdated(true);
         }}
       />
-      {settings.displayVectorStoreOptions === true &&
+      {settings.displayVectorStoreOptions === true && (
         <VectorConfig
           settings={settings.vector}
           secrets={newSecrets}
@@ -185,7 +186,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
             setUpdated(true);
           }}
         />
-      }
+      )}
 
       {errorState !== undefined && <Alert title={errorState} severity="error" />}
       {isUpdating ? (

--- a/packages/grafana-llm-app/src/components/AppConfig/DevSandbox.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/DevSandbox.tsx
@@ -37,7 +37,7 @@ const BasicChatTest = () => {
     if (!useStream) {
       // Make a single request to the LLM.
       const response = await openai.chatCompletions({
-        model: 'base',
+        model: openai.Model.BASE,
         messages: [
           { role: 'system', content: 'You are a cynical assistant.' },
           { role: 'user', content: message },
@@ -50,7 +50,7 @@ const BasicChatTest = () => {
     } else {
       // Stream the completions. Each element is the next stream chunk.
       const stream = openai.streamChatCompletions({
-        model: 'base',
+        model: openai.Model.BASE,
         messages: [
           { role: 'system', content: 'You are a cynical assistant.' },
           { role: 'user', content: message },

--- a/packages/grafana-llm-app/src/components/AppConfig/DevSandbox.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/DevSandbox.tsx
@@ -37,7 +37,7 @@ const BasicChatTest = () => {
     if (!useStream) {
       // Make a single request to the LLM.
       const response = await openai.chatCompletions({
-        model: openai.Model.BASE,
+        model: 'base',
         messages: [
           { role: 'system', content: 'You are a cynical assistant.' },
           { role: 'user', content: message },
@@ -50,7 +50,7 @@ const BasicChatTest = () => {
     } else {
       // Stream the completions. Each element is the next stream chunk.
       const stream = openai.streamChatCompletions({
-        model: openai.Model.BASE,
+        model: 'base',
         messages: [
           { role: 'system', content: 'You are a cynical assistant.' },
           { role: 'user', content: message },

--- a/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
@@ -5,9 +5,10 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Button, Card, Checkbox, FieldSet, Icon, useStyles2 } from '@grafana/ui';
 
 import { AppPluginSettings, Secrets, SecretsSet } from './AppConfig';
+import { ModelConfig } from './ModelConfig';
+import { DevSandbox } from './DevSandbox';
 import { OpenAIConfig, OpenAIProvider } from './OpenAI';
 import { OpenAILogo } from './OpenAILogo';
-import { DevSandbox} from './DevSandbox';
 
 // LLMOptions are the 3 possible UI options for LLMs (grafana-provided cloud-only).
 export type LLMOptions = 'grafana-provided' | 'openai' | 'disabled';
@@ -94,134 +95,143 @@ export function LLMConfig({
 
   return (
     <>
-    {process.env.NODE_ENV === 'development' && <DevSandbox/>}
-    <FieldSet label="OpenAI Settings" className={s.sidePadding}>
-      {allowGrafanaManagedLLM && (
-        <div onClick={selectGrafanaManaged}>
-          <Card
-            isSelected={llmOption === 'grafana-provided'}
-            // onClick={selectGrafanaManaged} // prevents events passing to children, use parent div instead!
-            className={s.cardWithoutBottomMargin}
-          >
-            <Card.Heading>Use OpenAI provided by Grafana</Card.Heading>
+      {process.env.NODE_ENV === 'development' && <DevSandbox />}
+      <FieldSet label="OpenAI Settings" className={s.sidePadding}>
+        {allowGrafanaManagedLLM && (
+          <div onClick={selectGrafanaManaged}>
+            <Card
+              isSelected={llmOption === 'grafana-provided'}
+              // onClick={selectGrafanaManaged} // prevents events passing to children, use parent div instead!
+              className={s.cardWithoutBottomMargin}
+            >
+              <Card.Heading>Use OpenAI provided by Grafana</Card.Heading>
+              <Card.Description>
+                <div>Enable LLM features in Grafana by using a connection to OpenAI that is provided by Grafana</div>
+                {llmOption === 'grafana-provided' && (
+                  <>
+                    <div className={s.openaiTermsBox}>
+                      <h4>Terms of Usage (Last updated: February 16th, 2024)</h4>
+                      <div>
+                        To enable OpenAI via Grafana Labs, please note that some data from your Grafana instance will be
+                        sent to OpenAI when you use the LLM-based features. Grafana Labs imposes usage limits for this
+                        service.
+                      </div>
+                      <div>
+                        Additionally, the following terms (&quot;AI Terms&quot;) are hereby added to and become part of
+                        your licensing agreement with Grafana Labs (the &quot;Agreement&quot;) as additional terms.
+                        Capitalized terms not defined in these AI Terms have the meanings given in the Agreement. These
+                        terms apply to your specific use of the OpenAI via Grafana Labs feature(s), and are separate,
+                        necessary terms regarding your use of this feature and therefore are not &apos;click-wrap&apos;,
+                        &apos;shrink-wrap&apos;, different or additional terms, or the like, to the extent your
+                        licensing agreement with Grafana Labs purports to supersede any such terms.
+                      </div>
+                      <ul>
+                        <li>Grafana Labs uses OpenAI&apos;s API platform to provide the LLM features.</li>
+                        <li>
+                          OpenAI does not train aggregated models on inputs or outputs of the API platform as used in
+                          connection with Grafana Labs Product(s).
+                        </li>
+                        <li>
+                          OpenAI does retain data for a short time in order to provide the services and monitor for
+                          abuse. All data sent to OpenAI is encrypted in transit and at rest.
+                        </li>
+                        <li>
+                          All features utilizing OpenAI are clearly marked in the Grafana Labs Product(s), and each
+                          feature sends minimal data to OpenAI&mdash;and only at the request of a user (for example,
+                          when a user clicks the button to request an Incident auto-summary).
+                        </li>
+                        <li>
+                          Grafana Labs will add new features regularly that utilize features connecting to OpenAI&apos;s
+                          APIs, which may include, but are not limited to:
+                          <ul>
+                            <li>Explaining Flamegraphs & offer suggestions to fix issues</li>
+                            <li>Incident auto-summary</li>
+                            <li>
+                              Suggesting names & descriptions for panels & dashboards, and summarize differences when
+                              saving changes
+                            </li>
+                            <li>Explaining error log lines in Sift</li>
+                            <li>Generating KQL queries in the Azure Data Explorer plugin</li>
+                          </ul>
+                        </li>
+                        <li>
+                          Visit the OpenAI trust portal for more detail about OpenAI:{' '}
+                          <Button
+                            size="sm"
+                            variant="secondary"
+                            onClick={(e) => {
+                              window.open('https://trust.openai.com/', '_blank');
+                              e.stopPropagation();
+                            }}
+                          >
+                            https://trust.openai.com/
+                          </Button>
+                        </li>
+                        <li>
+                          If you enable this feature, OpenAI will be a subprocessor of Grafana Labs for the purpose of
+                          any data processing agreement you may have in place with Grafana Labs.
+                        </li>
+                        <li>
+                          Disclaimer. Outputs are generated through machine learning processes and are not tested,
+                          verified, endorsed or guaranteed to be accurate, complete or current by Grafana Labs. You
+                          should independently review and verify all outputs as to appropriateness for any or all of
+                          your use cases or applications. The warranties, disclaimers, and limitations of liability in
+                          the Agreement apply to the AI Features.
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      By clicking the &quot;I Accept&quot; button, you agree to these additional AI Terms on behalf of
+                      yourself and/or your organization. Please read these terms carefully before proceeding. If you do
+                      not agree to these terms, do not click the &quot;I Accept&quot; button.
+                    </div>
+                    <Checkbox value={optIn} onClick={optInChange} label="I Accept" />
+                  </>
+                )}
+              </Card.Description>
+              <Card.Figure>
+                <Icon name="grafana" size="lg" />
+              </Card.Figure>
+            </Card>
+          </div>
+        )}
+        <div onClick={selectOpenAI}>
+          <Card isSelected={llmOption === 'openai'} className={s.cardWithoutBottomMargin}>
+            <Card.Heading>Use your own OpenAI account</Card.Heading>
             <Card.Description>
-              <div>Enable LLM features in Grafana by using a connection to OpenAI that is provided by Grafana</div>
-              {llmOption === 'grafana-provided' && (
-                <>
-                  <div className={s.openaiTermsBox}>
-                    <h4>Terms of Usage (Last updated: February 16th, 2024)</h4>
-                    <div>
-                      To enable OpenAI via Grafana Labs, please note that some data from your Grafana instance will be
-                      sent to OpenAI when you use the LLM-based features. Grafana Labs imposes usage limits for this
-                      service.
-                    </div>
-                    <div>
-                      Additionally, the following terms (&quot;AI Terms&quot;) are hereby added to and become part of
-                      your licensing agreement with Grafana Labs (the &quot;Agreement&quot;) as additional terms.
-                      Capitalized terms not defined in these AI Terms have the meanings given in the Agreement. These
-                      terms apply to your specific use of the OpenAI via Grafana Labs feature(s), and are separate,
-                      necessary terms regarding your use of this feature and therefore are not &apos;click-wrap&apos;,
-                      &apos;shrink-wrap&apos;, different or additional terms, or the like, to the extent your licensing
-                      agreement with Grafana Labs purports to supersede any such terms.
-                    </div>
-                    <ul>
-                      <li>Grafana Labs uses OpenAI&apos;s API platform to provide the LLM features.</li>
-                      <li>
-                        OpenAI does not train aggregated models on inputs or outputs of the API platform as used in
-                        connection with Grafana Labs Product(s).
-                      </li>
-                      <li>
-                        OpenAI does retain data for a short time in order to provide the services and monitor for abuse.
-                        All data sent to OpenAI is encrypted in transit and at rest.
-                      </li>
-                      <li>
-                        All features utilizing OpenAI are clearly marked in the Grafana Labs Product(s), and each
-                        feature sends minimal data to OpenAI&mdash;and only at the request of a user (for example, when
-                        a user clicks the button to request an Incident auto-summary).
-                      </li>
-                      <li>
-                        Grafana Labs will add new features regularly that utilize features connecting to OpenAI&apos;s
-                        APIs, which may include, but are not limited to:
-                        <ul>
-                          <li>Explaining Flamegraphs & offer suggestions to fix issues</li>
-                          <li>Incident auto-summary</li>
-                          <li>
-                            Suggesting names & descriptions for panels & dashboards, and summarize differences when
-                            saving changes
-                          </li>
-                          <li>Explaining error log lines in Sift</li>
-                          <li>Generating KQL queries in the Azure Data Explorer plugin</li>
-                        </ul>
-                      </li>
-                      <li>
-                        Visit the OpenAI trust portal for more detail about OpenAI:{' '}
-                        <Button
-                          size="sm"
-                          variant="secondary"
-                          onClick={(e) => {
-                            window.open('https://trust.openai.com/', '_blank');
-                            e.stopPropagation();
-                          }}
-                        >
-                          https://trust.openai.com/
-                        </Button>
-                      </li>
-                      <li>
-                        If you enable this feature, OpenAI will be a subprocessor of Grafana Labs for the purpose of any
-                        data processing agreement you may have in place with Grafana Labs.
-                      </li>
-                      <li>
-                        Disclaimer. Outputs are generated through machine learning processes and are not tested,
-                        verified, endorsed or guaranteed to be accurate, complete or current by Grafana Labs. You should
-                        independently review and verify all outputs as to appropriateness for any or all of your use
-                        cases or applications. The warranties, disclaimers, and limitations of liability in the
-                        Agreement apply to the AI Features.
-                      </li>
-                    </ul>
-                  </div>
-                  <div>
-                    By clicking the &quot;I Accept&quot; button, you agree to these additional AI Terms on behalf of
-                    yourself and/or your organization. Please read these terms carefully before proceeding. If you do
-                    not agree to these terms, do not click the &quot;I Accept&quot; button.
-                  </div>
-                  <Checkbox value={optIn} onClick={optInChange} label="I Accept" />
-                </>
+              <div>Enable LLM features in Grafana using your own OpenAI account</div>
+              {llmOption === 'openai' && (
+                <OpenAIConfig
+                  settings={settings.openAI ?? {}}
+                  onChange={(openAI) => onChange({ ...settings, openAI })}
+                  secrets={secrets}
+                  secretsSet={secretsSet}
+                  onChangeSecrets={onChangeSecrets}
+                />
               )}
             </Card.Description>
             <Card.Figure>
-              <Icon name="grafana" size="lg" />
+              <OpenAILogo width={20} height={20} />
             </Card.Figure>
           </Card>
         </div>
-      )}
-      <div onClick={selectOpenAI}>
-        <Card isSelected={llmOption === 'openai'} className={s.cardWithoutBottomMargin}>
-          <Card.Heading>Use your own OpenAI account</Card.Heading>
-          <Card.Description>
-            <div>Enable LLM features in Grafana using your own OpenAI account</div>
-            {llmOption === 'openai' && (
-              <OpenAIConfig
-                settings={settings.openAI ?? {}}
-                onChange={(openAI) => onChange({ ...settings, openAI })}
-                secrets={secrets}
-                secretsSet={secretsSet}
-                onChangeSecrets={onChangeSecrets}
-              />
-            )}
-          </Card.Description>
+        <Card isSelected={llmOption === 'disabled'} onClick={selectLLMDisabled} className={s.cardWithoutBottomMargin}>
+          <Card.Heading>Disable all LLM features in Grafana</Card.Heading>
+          <Card.Description>&nbsp;</Card.Description>
           <Card.Figure>
-            <OpenAILogo width={20} height={20} />
+            <Icon name="times" size="lg" />
           </Card.Figure>
         </Card>
-      </div>
-      <Card isSelected={llmOption === 'disabled'} onClick={selectLLMDisabled} className={s.cardWithoutBottomMargin}>
-        <Card.Heading>Disable all LLM features in Grafana</Card.Heading>
-        <Card.Description>&nbsp;</Card.Description>
-        <Card.Figure>
-          <Icon name="times" size="lg" />
-        </Card.Figure>
-      </Card>
-    </FieldSet>
+      </FieldSet>
+      {llmOption === 'openai' && (
+        <FieldSet label="Models" className={s.sidePadding}>
+          <ModelConfig
+            provider={settings.openAI?.provider ?? 'openai'}
+            settings={settings.models ?? { mapping: {} }}
+            onChange={(models) => onChange({ ...settings, models })}
+          />
+        </FieldSet>
+      )}
     </>
   );
 }
@@ -246,11 +256,11 @@ export const getStyles = (theme: GrafanaTheme2) => ({
 
     ' ul': {
       // space important, matches all children of type 'ul'
-      'paddingLeft': theme.spacing(2),
+      paddingLeft: theme.spacing(2),
     },
     '> ul > li:not(:last-child)': {
       // slight vertical padding between main bullet points
-      'marginBottom': theme.spacing(0.5),
+      marginBottom: theme.spacing(0.5),
     },
   }),
   cardWithoutBottomMargin: css`

--- a/packages/grafana-llm-app/src/components/AppConfig/ModelConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/ModelConfig.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+
+import { Field, FieldSet, Input, Label, Select } from '@grafana/ui';
+import { openai } from '@grafana/llm';
+
+import { OpenAIProvider } from './OpenAI';
+
+export type ModelMapping = Partial<Record<openai.Model, string>>;
+
+export interface ModelSettings {
+  default?: openai.Model;
+  mapping: ModelMapping;
+}
+
+export interface ModelMappingConfig {
+  model: openai.Model;
+  name: string;
+  label: string;
+  description: string;
+}
+const DEFAULT_MODEL = openai.Model.BASE;
+const DEFAULT_MODEL_NAMES: ModelMappingConfig[] = [
+  {
+    model: openai.Model.BASE,
+    name: 'gpt-3.5-turbo',
+    label: 'Base',
+    description: 'A fast and cost-effective model for efficient, high-throughput tasks.',
+  },
+  {
+    model: openai.Model.LARGE,
+    name: 'gpt-4-turbo',
+    label: 'Large',
+    description:
+      'A larger, higher cost model for more advanced tasks with longer context windows.',
+  },
+];
+
+const initModelSettings = (settings: ModelSettings): ModelSettings => ({
+  default: settings.default ?? DEFAULT_MODEL,
+  // If the settings are empty, set the default models
+  // If the settings are not empty, filter out any models that are not in the default list
+  mapping: settings.mapping
+    ? Object.fromEntries(
+      Object.entries(settings.mapping)
+        .filter(([m, _]) => DEFAULT_MODEL_NAMES.find((d) => d.model === m))
+    ) as ModelMapping
+    : Object.fromEntries(DEFAULT_MODEL_NAMES.map((entry) => ([entry.model, entry.name]))) as ModelMapping,
+});
+
+export function ModelConfig({
+  provider,
+  settings,
+  onChange,
+}: {
+  provider: OpenAIProvider;
+  settings: ModelSettings;
+  onChange: (settings: ModelSettings) => void;
+}) {
+  settings = initModelSettings(settings);
+
+  return (
+    <FieldSet>
+      <Field
+        label="Default Model"
+        description="The default model is used when no model is specified in the chat request."
+      >
+        <Select
+          options={DEFAULT_MODEL_NAMES.map((entry) => ({ label: entry.label, value: entry.model }))}
+          width={60}
+          value={settings.default ?? DEFAULT_MODEL}
+          onChange={(e) => onChange({ ...settings, default: e.value ?? openai.Model.BASE })}
+        />
+      </Field>
+
+      {/*
+        Only show custom model mappings for non-Azure providers.
+        When using the Azure provider users can just customise the deployments
+        instead.
+      */ }
+      {provider !== "azure" && (
+        <>
+          <Label description="Set custom models used for LLM features.">Custom overrides</Label>
+          {DEFAULT_MODEL_NAMES.map((entry, i) => {
+            const modelSetting = settings.mapping[entry.model];
+            // If the model is not in the settings, add it with the default name
+            if (!modelSetting) {
+              onChange({ ...settings, mapping: { ...settings.mapping, [entry.model]: entry.name } });
+            }
+
+            return (
+              <Field key={i} label={`${entry.label}`} description={entry.description}>
+                <Input
+                  width={60}
+                  type="text"
+                  name="model"
+                  value={modelSetting ?? entry.name}
+                  onChange={(e) => {
+                    const newModelName = e.currentTarget.value;
+                    const newMapping = {
+                      ...settings.mapping,
+                      [entry.model]: newModelName,
+                    };
+                    onChange({ ...settings, mapping: newMapping });
+                  }}
+                />
+              </Field>
+            );
+          })}
+        </>
+      )}
+    </FieldSet>
+  );
+}

--- a/packages/grafana-llm-app/src/components/AppConfig/ModelConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/ModelConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Field, FieldSet, Input, Label, Select } from '@grafana/ui';
+import { Badge, Button, Divider, Field, FieldSet, Input, Label } from '@grafana/ui';
 import { openai } from '@grafana/llm';
 
 import { OpenAIProvider } from './OpenAI';
@@ -13,38 +13,36 @@ export interface ModelSettings {
 }
 
 export interface ModelMappingConfig {
-  model: openai.Model;
+  id: openai.Model;
   name: string;
   label: string;
   description: string;
 }
-const DEFAULT_MODEL = openai.Model.BASE;
-const DEFAULT_MODEL_NAMES: ModelMappingConfig[] = [
+const DEFAULT_MODEL_ID = openai.Model.BASE;
+const MODEL_MAPPING_CONFIG: ModelMappingConfig[] = [
   {
-    model: openai.Model.BASE,
+    id: openai.Model.BASE,
     name: 'gpt-3.5-turbo',
     label: 'Base',
     description: 'A fast and cost-effective model for efficient, high-throughput tasks.',
   },
   {
-    model: openai.Model.LARGE,
+    id: openai.Model.LARGE,
     name: 'gpt-4-turbo',
     label: 'Large',
-    description:
-      'A larger, higher cost model for more advanced tasks with longer context windows.',
+    description: 'A larger, higher cost model for more advanced tasks with longer context windows.',
   },
 ];
 
 const initModelSettings = (settings: ModelSettings): ModelSettings => ({
-  default: settings.default ?? DEFAULT_MODEL,
+  default: settings.default ?? DEFAULT_MODEL_ID,
   // If the settings are empty, set the default models
   // If the settings are not empty, filter out any models that are not in the default list
   mapping: settings.mapping
-    ? Object.fromEntries(
-      Object.entries(settings.mapping)
-        .filter(([m, _]) => DEFAULT_MODEL_NAMES.find((d) => d.model === m))
-    ) as ModelMapping
-    : Object.fromEntries(DEFAULT_MODEL_NAMES.map((entry) => ([entry.model, entry.name]))) as ModelMapping,
+    ? (Object.fromEntries(
+        Object.entries(settings.mapping).filter(([m, _]) => MODEL_MAPPING_CONFIG.find((d) => d.id === m))
+      ) as ModelMapping)
+    : (Object.fromEntries(MODEL_MAPPING_CONFIG.map((entry) => [entry.id, entry.name])) as ModelMapping),
 });
 
 export function ModelConfig({
@@ -57,53 +55,64 @@ export function ModelConfig({
   onChange: (settings: ModelSettings) => void;
 }) {
   settings = initModelSettings(settings);
+  const setDefault = (model: openai.Model) => onChange({ ...settings, default: model });
 
   return (
     <FieldSet>
-      <Field
-        label="Default Model"
-        description="The default model is used when no model is specified in the chat request."
-      >
-        <Select
-          options={DEFAULT_MODEL_NAMES.map((entry) => ({ label: entry.label, value: entry.model }))}
-          width={60}
-          value={settings.default ?? DEFAULT_MODEL}
-          onChange={(e) => onChange({ ...settings, default: e.value ?? openai.Model.BASE })}
-        />
-      </Field>
-
       {/*
         Only show custom model mappings for non-Azure providers.
         When using the Azure provider users can just customise the deployments
         instead.
-      */ }
-      {provider !== "azure" && (
+      */}
+      {provider !== 'azure' && (
         <>
-          <Label description="Set custom models used for LLM features.">Custom overrides</Label>
-          {DEFAULT_MODEL_NAMES.map((entry, i) => {
-            const modelSetting = settings.mapping[entry.model];
+          <Label description="Map custom models used for LLM features. The default model is used when no model is specified in the chat request.">
+            Model mappings
+          </Label>
+          {MODEL_MAPPING_CONFIG.map((entry, i) => {
+            const modelSetting = settings.mapping[entry.id];
             // If the model is not in the settings, add it with the default name
             if (!modelSetting) {
-              onChange({ ...settings, mapping: { ...settings.mapping, [entry.model]: entry.name } });
+              onChange({ ...settings, mapping: { ...settings.mapping, [entry.id]: entry.name } });
             }
+            const isDefault = settings.default === entry.id;
+            const FieldLabel = (
+              <>
+                <Label>
+                  {entry.label}
+                  <Divider direction="vertical" spacing={1} />
+                  {isDefault ? (
+                    <div style={{ margin: '1px auto' }}>
+                      <Badge text="Default" color="blue" />
+                    </div>
+                  ) : (
+                    <Button variant="secondary" size="sm" onClick={() => setDefault(entry.id)}>
+                      Set as default
+                    </Button>
+                  )}
+                </Label>
+              </>
+            );
 
             return (
-              <Field key={i} label={`${entry.label}`} description={entry.description}>
-                <Input
-                  width={60}
-                  type="text"
-                  name="model"
-                  value={modelSetting ?? entry.name}
-                  onChange={(e) => {
-                    const newModelName = e.currentTarget.value;
-                    const newMapping = {
-                      ...settings.mapping,
-                      [entry.model]: newModelName,
-                    };
-                    onChange({ ...settings, mapping: newMapping });
-                  }}
-                />
-              </Field>
+              <>
+                <Field key={i} label={FieldLabel} description={entry.description}>
+                  <Input
+                    width={60}
+                    type="text"
+                    name="model"
+                    value={modelSetting ?? entry.name}
+                    onChange={(e) => {
+                      const newModelName = e.currentTarget.value;
+                      const newMapping = {
+                        ...settings.mapping,
+                        [entry.id]: newModelName,
+                      };
+                      onChange({ ...settings, mapping: newMapping });
+                    }}
+                  />
+                </Field>
+              </>
             );
           })}
         </>

--- a/packages/grafana-llm-app/src/components/AppConfig/ModelConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/ModelConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Badge, Button, Divider, Field, FieldSet, Input, Label } from '@grafana/ui';
+import { Badge, Button, Divider, Field, FieldSet, Input, Label, Select } from '@grafana/ui';
 import { openai } from '@grafana/llm';
 
 import { OpenAIProvider } from './OpenAI';
@@ -64,6 +64,19 @@ export function ModelConfig({
         When using the Azure provider users can just customise the deployments
         instead.
       */}
+      {provider === 'azure' && (
+        <Field
+          label="Default Model"
+          description="The default model is used when no model is specified in the chat request."
+        >
+          <Select
+            options={MODEL_MAPPING_CONFIG.map((entry) => ({ label: entry.label, value: entry.id }))}
+            width={60}
+            value={settings.default ?? DEFAULT_MODEL_ID}
+            onChange={(e) => setDefault(e.value ?? DEFAULT_MODEL_ID as openai.Model)}
+          />
+        </Field>
+      )}
       {provider !== 'azure' && (
         <>
           <Label description="Map custom models used for LLM features. The default model is used when no model is specified in the chat request.">

--- a/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent } from 'react';
 
+import { openai } from '@grafana/llm';
 import { Field, FieldSet, Input, SecretInput, Select, useStyles2 } from '@grafana/ui';
 
 import { SelectableValue } from '@grafana/data';
@@ -106,11 +107,11 @@ export function OpenAIConfig({
       {settings.provider === 'azure' && (
         <Field
           label="Azure OpenAI Model Mapping"
-          description="Mapping from OpenAI model names to Azure deployment names."
+          description="Mapping from model name to Azure deployment name."
         >
           <AzureModelDeploymentConfig
             modelMapping={settings.azureModelMapping ?? []}
-            modelNames={['gpt-3.5-turbo', 'gpt-4']}
+            modelNames={Object.values(openai.Model)}
             onChange={(azureModelMapping) =>
               onChange({
                 ...settings,


### PR DESCRIPTION
Exposes model abstraction settings in frontend
<img width="540" alt="Screenshot 2024-05-10 at 14 27 31" src="https://github.com/grafana/grafana-llm-app/assets/13647408/2f7b5d47-6782-4273-9445-df96c7f488a4">
when using Azure, only the default settings are shown
<img width="530" alt="Screenshot 2024-05-10 at 14 43 27" src="https://github.com/grafana/grafana-llm-app/assets/13647408/f28be130-2316-4867-8bd4-14a14c334ba1">


Split from https://github.com/grafana/grafana-llm-app/pull/331
Resolves https://github.com/grafana/grafana-llm-app/issues/323