### PR TITLE
llm-frontend: remove function calling feature

### DIFF
--- a/packages/grafana-llm-frontend/src/openai.ts
+++ b/packages/grafana-llm-frontend/src/openai.ts
@@ -95,18 +95,6 @@ export interface ChatCompletionsRequest {
   model?: Model | DeprecatedString;
   /** A list of messages comprising the conversation so far. */
   messages: Message[];
-  /** A list of functions the model may generate JSON inputs for. */
-  functions?: Function[];
-  /**
-   * Controls how the model responds to function calls.
-   *
-   * "none" means the model does not call a function, and responds to the end-user.
-   * "auto" means the model can pick between an end-user or calling a function.
-   * Specifying a particular function via {"name": "my_function"} forces the model to call that function.
-   *
-   * "none" is the default when no functions are present. "auto" is the default if functions are present.
-   */
-  function_call?: 'none' | 'auto' | { name: string };
   /**
    * What sampling temperature to use, between 0 and 2.
    * Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.


### PR DESCRIPTION
We can add it back in as we support more features in the app backend for non-OpenAI models and vendors.
