### PR TITLE
Release version 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22110,7 +22110,7 @@
     },
     "packages/grafana-llm-app": {
       "name": "@grafana/llm-app",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",
@@ -22195,7 +22195,7 @@
     },
     "packages/grafana-llm-frontend": {
       "name": "@grafana/llm",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grafana/data": "10.4.0",

--- a/packages/grafana-llm-app/CHANGELOG.md
+++ b/packages/grafana-llm-app/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 0.10.0
+
+- Breaking: use `base` and `large` model names instead of `small`/`medium`/`large` (#334)
+- Breaking: remove function calling arguments from `@grafana/llm` package (#343)
+- Allow customisation of mapping between abstract model and provider model, and default model (#337, #338, #340)
+- Make the `model` field optional for chat completions & chat completion stream endpoints (#341)
+- Don't preload the plugin to avoid slowing down Grafana load times (#339)
+
 ## 0.9.1
 
 - Fix handling of streaming requests made via resource endpoints (#326)

--- a/packages/grafana-llm-app/package.json
+++ b/packages/grafana-llm-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/llm-app",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Plugin to easily allow llm based extensions to grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/packages/grafana-llm-frontend/package.json
+++ b/packages/grafana-llm-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/llm",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "A grafana library for llm",
   "exports": {
     ".": {


### PR DESCRIPTION
Changes:

- Breaking: use `base` and `large` model names instead of `small`/`medium`/`large` (#334)
- Breaking: remove function calling arguments from `@grafana/llm` package (#343)
- Allow customisation of mapping between abstract model and provider model, and default model (#337, #338, #340)
- Make the `model` field optional for chat completions & chat completion stream endpoints (#341)
- Don't preload the plugin to avoid slowing down Grafana load times (#339)
