### PR TITLE
Avoid using global variable to determine whether to ignore padding

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/app.go
+++ b/packages/grafana-llm-app/pkg/plugin/app.go
@@ -38,6 +38,10 @@ type App struct {
 	settings         *Settings
 	saToken          string
 	grafanaAppURL    string
+
+	// ignoreResponsePadding is a flag to ignore padding in responses.
+	// It should only ever be set in tests.
+	ignoreResponsePadding bool
 }
 
 // NewApp creates a new example *App instance.

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider.go
@@ -101,12 +101,14 @@ type ChatCompletionStreamResponse struct {
 	Padding string `json:"p,omitempty"`
 	// Error indicates that an error occurred mid-stream.
 	Error error `json:"-"`
+
+	// ignorePadding is a flag to ignore padding in responses.
+	// It should only ever be set in tests.
+	ignorePadding bool
 }
 
-var unsafeDisablePadding = false
-
 func (r ChatCompletionStreamResponse) MarshalJSON() ([]byte, error) {
-	if !unsafeDisablePadding {
+	if !r.ignorePadding {
 		// Define a wrapper type to avoid infinite recursion when calling MarshalJSON below.
 		r.Padding = strings.Repeat("p", rand.Int()%35)
 	}

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider.go
@@ -110,7 +110,7 @@ type ChatCompletionStreamResponse struct {
 func (r ChatCompletionStreamResponse) MarshalJSON() ([]byte, error) {
 	if !r.ignorePadding {
 		// Define a wrapper type to avoid infinite recursion when calling MarshalJSON below.
-		r.Padding = strings.Repeat("p", rand.Int()%35)
+		r.Padding = strings.Repeat("p", rand.Int()%35+1)
 	}
 	type Wrapper ChatCompletionStreamResponse
 	a := (Wrapper)(r)

--- a/packages/grafana-llm-app/pkg/plugin/resources.go
+++ b/packages/grafana-llm-app/pkg/plugin/resources.go
@@ -501,6 +501,9 @@ func (a *App) handleChatCompletionsStream(
 			writeErr = handleStreamError(w, resp.Error, http.StatusInternalServerError)
 			continue
 		}
+		if a.ignoreResponsePadding {
+			resp.ignorePadding = true
+		}
 		chunk, err := json.Marshal(resp)
 		if err != nil {
 			writeErr = handleStreamError(w, errors.New("failed to marshal streaming response"), http.StatusInternalServerError)

--- a/packages/grafana-llm-app/pkg/plugin/resources_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/resources_test.go
@@ -188,10 +188,6 @@ func newMockOpenAIServer(t *testing.T) *mockServer {
 }
 
 func TestCallOpenAIProxy(t *testing.T) {
-	unsafeDisablePadding = true
-	t.Cleanup(func() {
-		unsafeDisablePadding = false
-	})
 	// Set up and run test cases
 	for _, tc := range []struct {
 		name string
@@ -536,6 +532,8 @@ func TestCallOpenAIProxy(t *testing.T) {
 			if !ok {
 				t.Fatal("inst must be of type *App")
 			}
+
+			app.ignoreResponsePadding = true
 
 			var r mockCallResourceResponseSender
 			err = app.CallResource(ctx, &backend.CallResourceRequest{


### PR DESCRIPTION
Instead, use a non-configurable flag on the app which can only be set manually,
and set it to true in the test where we need to test response bodies.

Also, ensure we always send at least _some_ padding, since the padding field is tagged with `omitempty`.

Fixes #332.
