### PR TITLE
fix: add 'files' to frontend package.json

### DIFF
--- a/packages/grafana-llm-frontend/package.json
+++ b/packages/grafana-llm-frontend/package.json
@@ -9,6 +9,11 @@
       "require": "./dist/index.js"
     }
   },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/esm/index.js",
   "source": "./src/index.ts",


### PR DESCRIPTION
Without this, the `src` directory is included in the tarball created
by `npm publish`, but we need the `dist` directory.

Running `npm publish --dry-run` before:

    npm notice
    npm notice 📦  @grafana/llm@0.10.4
    npm notice === Tarball Contents ===
    npm notice 45B    .eslintrc
    npm notice 11.4kB LICENSE
    npm notice 2.1kB  README.md
    npm notice 641B   jest.config.js
    npm notice 1.2kB  package.json
    npm notice 1.1kB  rollup.config.mjs
    npm notice 666B   src/constants.ts
    npm notice 72B    src/index.ts
    npm notice 1.2kB  src/openai.test.ts
    npm notice 21.5kB src/openai.ts
    npm notice 1.4kB  src/types.ts
    npm notice 1.2kB  src/vector.test.ts
    npm notice 4.4kB  src/vector.ts
    npm notice 280B   tsconfig.json
    npm notice === Tarball Details ===
    npm notice name:          @grafana/llm
    npm notice version:       0.10.4
    npm notice filename:      grafana-llm-0.10.4.tgz
    npm notice package size:  13.9 kB
    npm notice unpacked size: 47.2 kB
    npm notice shasum:        6e0ef39b093decaec6130c2d5e158f8e66aad253
    npm notice integrity:     sha512-Kur9VhrWMeLb6[...]WMmH2TwL5Tk6Q==
    npm notice total files:   14
    npm notice
    npm notice Publishing to https://registry.npmjs.org with tag latest and default access (dry-run)
    + @grafana/llm@0.10.4

After:

    npm notice
    npm notice 📦  @grafana/llm@0.10.4
    npm notice === Tarball Contents ===
    npm notice 11.4kB LICENSE
    npm notice 2.1kB  README.md
    npm notice 562B   dist/esm/constants.js
    npm notice 1.1kB  dist/esm/constants.js.map
    npm notice 150B   dist/esm/index.js
    npm notice 92B    dist/esm/index.js.map
    npm notice 7.0kB  dist/esm/openai.js
    npm notice 28.5kB dist/esm/openai.js.map
    npm notice 2.2kB  dist/esm/vector.js
    npm notice 6.6kB  dist/esm/vector.js.map
    npm notice 19.2kB dist/index.d.ts
    npm notice 10.0kB dist/index.js
    npm notice 36.4kB dist/index.js.map
    npm notice 1.3kB  package.json
    npm notice === Tarball Details ===
    npm notice name:          @grafana/llm
    npm notice version:       0.10.4
    npm notice filename:      grafana-llm-0.10.4.tgz
    npm notice package size:  27.9 kB
    npm notice unpacked size: 126.6 kB
    npm notice shasum:        a382428bc1bfd2cc46fcc033d3e39968cc530942
    npm notice integrity:     sha512-bDdCH2xAdXNu3[...]if/7bPQ37quHQ==
    npm notice total files:   14
    npm notice
    npm notice Publishing to https://registry.npmjs.org with tag latest and default access (dry-run)
    + @grafana/llm@0.10.4
