### PR TITLE
fix: remove reference to deprecated CSS class

### DIFF
--- a/packages/grafana-llm-app/src/components/AppConfig/HealthCheck.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/HealthCheck.tsx
@@ -71,11 +71,7 @@ const getAlertSeverity = (status: string, details: HealthCheckDetails): AlertVar
 export function ShowHealthCheckResult(props: HealthCheckResult) {
   let severity = getAlertVariant(props.status ?? 'error');
   if (!isHealthCheckDetails(props.details)) {
-    return (
-      <div className="gf-form-group p-t-2">
-        <Alert severity={severity} title={props.message} />
-      </div>
-    );
+    return <Alert severity={severity} title={props.message} />;
   }
 
   severity = getAlertSeverity(props.status ?? 'error', props.details);


### PR DESCRIPTION
For some reason we were using a div with gf-form-group
and p-t-2 classes, which feels unnecessary. I've just removed
the wrapper div because I don't think it does anything
(it probably came from a copy/paste).

Fixes #377.
