### PR TITLE
fix: show alert if Grafana Live is disabled

### DIFF
--- a/packages/grafana-llm-app/src/components/AppConfig/HealthCheck.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/HealthCheck.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { HealthCheckResult } from '@grafana/runtime';
+import { HealthCheckResult, config } from '@grafana/runtime';
 import { Alert, AlertVariant, VerticalGroup } from '@grafana/ui';
 
 interface HealthCheckDetails {
@@ -83,10 +83,31 @@ export function ShowHealthCheckResult(props: HealthCheckResult) {
     (typeof props.details.vector === 'object' && props.details.vector.enabled);
   return (
     <VerticalGroup>
+      <ShowGrafanaHealth />
       {showOpenAI && <ShowOpenAIHealth openAI={props.details.openAI} />}
       {showVector && <ShowVectorHealth vector={props.details.vector} />}
     </VerticalGroup>
   );
+}
+
+function ShowGrafanaHealth() {
+  if (config.liveEnabled) {
+    return null;
+  }
+  return (
+    <Alert
+      title="Grafana Live is disabled"
+      severity="warning"
+    >
+      <div>
+        Grafana Live is disabled. This plugin requires Grafana Live to be enabled in order to function correctly.
+      </div>
+      <div>
+        Set the <a href="https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#max_connections"><code>max_connections</code></a> setting to a non-zero value
+        in the Grafana configuration file to enable Grafana Live.
+      </div>
+    </Alert>
+  )
 }
 
 function ShowOpenAIHealth({ openAI }: { openAI: OpenAIHealthDetails | boolean }) {


### PR DESCRIPTION
Relates to #382.

![Screenshot 2024-06-20 at 16-56-12 LLM - Plugins - Plugins and data - Administration - Grafana](https://github.com/grafana/grafana-llm-app/assets/5464991/1bb2172a-d521-445c-916d-500acc3ec379)
