### PR TITLE
Add validation to OpenAI URL

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/openai_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/openai_provider.go
@@ -24,6 +24,11 @@ func NewOpenAIProvider(settings OpenAISettings, models *ModelSettings) (LLMProvi
 		Timeout: 2 * time.Minute,
 	}
 	cfg := openai.DefaultConfig(settings.apiKey)
+	// validate url
+	_, err := url.Parse(settings.URL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid url: %w", err)
+	}
 	base, err := url.JoinPath(settings.URL, "/v1")
 	if err != nil {
 		return nil, fmt.Errorf("join url: %w", err)

--- a/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
@@ -14,6 +14,23 @@ import { OpenAISettings } from './OpenAI';
 import { VectorConfig, VectorSettings } from './Vector';
 ///////////////////////
 
+const validateUrl = (url: string): [boolean, string] => {
+  try {
+    const parsedURL = new URL(url);
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      return [false, 'URL must start with "http://" or "https://"'];
+    }
+    // make sure there are no spaces in the hostname or subdomain
+    const hostnameUnescaped = decodeURIComponent(parsedURL.hostname);
+    if (hostnameUnescaped.includes(' ')) {
+      return [false, 'URL cannot contain spaces in the hostname or subdomain'];
+    }
+    return [true, ''];
+  } catch (error) {
+    return [false, 'Invalid URL'];
+  }
+};
+
 export interface AppPluginSettings {
   openAI?: OpenAISettings;
   vector?: VectorSettings;
@@ -65,6 +82,13 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
     // Check if Grafana-provided OpenAI enabled, that it has been opted-in
     if (settings?.openAI?.provider === 'grafana' && !managedLLMOptIn) {
       return 'You must click the "I Accept" checkbox to use OpenAI provided by Grafana';
+    }
+    // Validate custom OpenAI URL
+    if (settings?.openAI?.url) {
+      const [isValid, error] = validateUrl(settings.openAI.url);
+      if (!isValid) {
+        return `Invalid OpenAI API URL: ${error}`;
+      }
     }
     return;
   };


### PR DESCRIPTION
Invalidate URLs that have spaces in the hostname since golang doesn't like that
e.g. `https://api.open ai.com` would throw an error `invalid character "" in host name`

This prevents saving invalid URLs in the form:
<img width="742" alt="Screenshot 2024-07-17 at 13 47 40" src="https://github.com/user-attachments/assets/41f756b9-f24e-4467-9b8f-7c1fa9023940">

