### PR TITLE
Create LLMProvider only when needed

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/app.go
+++ b/packages/grafana-llm-app/pkg/plugin/app.go
@@ -31,7 +31,6 @@ type App struct {
 
 	vectorService vector.Service
 
-	llmProvider      LLMProvider
 	healthCheckMutex sync.Mutex
 	healthOpenAI     *openAIHealthDetails
 	healthVector     *vectorHealthDetails
@@ -60,29 +59,6 @@ func NewApp(ctx context.Context, appSettings backend.AppInstanceSettings) (insta
 	if app.settings.Models == nil {
 		// backwards-compat: if Model settings is nil, use the default one
 		app.settings.Models = DEFAULT_MODEL_SETTINGS
-	}
-
-	switch app.settings.OpenAI.Provider {
-	case openAIProviderOpenAI:
-		p, err := NewOpenAIProvider(app.settings.OpenAI, app.settings.Models)
-		if err != nil {
-			return nil, err
-		}
-		app.llmProvider = p
-	case openAIProviderAzure:
-		p, err := NewAzureProvider(app.settings.OpenAI, app.settings.Models.Default)
-		if err != nil {
-			return nil, err
-		}
-		app.llmProvider = p
-	case openAIProviderGrafana:
-		p, err := NewGrafanaProvider(*app.settings)
-		if err != nil {
-			return nil, err
-		}
-		app.llmProvider = p
-	case openAIProviderTest:
-		app.llmProvider = &app.settings.OpenAI.TestProvider
 	}
 
 	// Use a httpadapter (provided by the SDK) for resource calls. This allows us

--- a/packages/grafana-llm-app/pkg/plugin/health.go
+++ b/packages/grafana-llm-app/pkg/plugin/health.go
@@ -45,6 +45,11 @@ func getVersion() string {
 }
 
 func (a *App) testOpenAIModel(ctx context.Context, model Model) error {
+	llmProvider, err := createProvider(a.settings)
+	if err != nil {
+		return err
+	}
+
 	req := ChatCompletionRequest{
 		Model: model,
 		ChatCompletionRequest: openai.ChatCompletionRequest{
@@ -54,7 +59,7 @@ func (a *App) testOpenAIModel(ctx context.Context, model Model) error {
 			MaxTokens: 1,
 		},
 	}
-	_, err := a.llmProvider.ChatCompletion(ctx, req)
+	_, err = llmProvider.ChatCompletion(ctx, req)
 	if err != nil {
 		return err
 	}

--- a/packages/grafana-llm-app/pkg/plugin/provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/provider.go
@@ -1,0 +1,18 @@
+package plugin
+
+import "errors"
+
+func createProvider(settings *Settings) (LLMProvider, error) {
+	switch settings.OpenAI.Provider {
+	case openAIProviderOpenAI:
+		return NewOpenAIProvider(settings.OpenAI, settings.Models)
+	case openAIProviderAzure:
+		return NewAzureProvider(settings.OpenAI, settings.Models.Default)
+	case openAIProviderGrafana:
+		return NewGrafanaProvider(*settings)
+	case openAIProviderTest:
+		return &settings.OpenAI.TestProvider, nil
+	default:
+		return nil, errors.New("Invalid OpenAI Provider supplied")
+	}
+}

--- a/packages/grafana-llm-app/pkg/plugin/stream.go
+++ b/packages/grafana-llm-app/pkg/plugin/stream.go
@@ -32,11 +32,16 @@ func (a *App) runOpenAIChatCompletionsStream(ctx context.Context, req *backend.R
 		return fmt.Errorf("Unable to unmarshal request body: %w", err)
 	}
 
+	llmProvider, err := createProvider(a.settings)
+	if err != nil {
+		return err
+	}
+
 	// Always set stream to true for streaming requests.
 	requestBody.Stream = true
 
 	// Delegate to configured provider for chat completions stream.
-	c, err := a.llmProvider.ChatCompletionStream(ctx, requestBody)
+	c, err := llmProvider.ChatCompletionStream(ctx, requestBody)
 	if err != nil {
 		return fmt.Errorf("establish chat completions stream: %w", err)
 	}


### PR DESCRIPTION
When reading/writing settings, we don't need to create any LLMProvider.

Avoiding creating the LLMProvider means we avoid validating the settings passed to the provider, which may be incorrect.

Fixes https://github.com/grafana/support-escalations/issues/11496