### PR TITLE
Use non-crypto UUID generation for stream request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6863,6 +6863,12 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
@@ -22107,7 +22113,7 @@
     },
     "packages/grafana-llm-app": {
       "name": "@grafana/llm-app",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",
@@ -22200,15 +22206,29 @@
         "react": "18.3.1",
         "react-use": "17.5.0",
         "rxjs": "7.8.1",
-        "semver": "7.6.2"
+        "semver": "7.6.2",
+        "uuid": "10.0.0"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",
+        "@types/uuid": "^10.0.0",
         "rollup": "^4.13.0",
         "rollup-plugin-dts": "^6.1.1",
         "rollup-plugin-esbuild": "^6.1.1",
         "rollup-plugin-node-externals": "^7.0.1",
         "typescript": "5.3.3"
+      }
+    },
+    "packages/grafana-llm-frontend/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     }
   }

--- a/packages/grafana-llm-frontend/package.json
+++ b/packages/grafana-llm-frontend/package.json
@@ -34,6 +34,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",
+    "@types/uuid": "^10.0.0",
     "rollup": "^4.13.0",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-esbuild": "^6.1.1",
@@ -46,6 +47,7 @@
     "react": "18.3.1",
     "react-use": "17.5.0",
     "rxjs": "7.8.1",
-    "semver": "7.6.2"
+    "semver": "7.6.2",
+    "uuid": "10.0.0"
   }
 }

--- a/packages/grafana-llm-frontend/src/openai.ts
+++ b/packages/grafana-llm-frontend/src/openai.ts
@@ -20,6 +20,7 @@ import React, { useEffect, useCallback, useState } from 'react';
 import { useAsync } from 'react-use';
 import { pipe, Observable, UnaryFunction, Subscription } from 'rxjs';
 import { filter, map, scan, takeWhile, tap } from 'rxjs/operators';
+import { v4 as uuidv4 } from 'uuid';
 
 import { LLM_PLUGIN_ID, LLM_PLUGIN_ROUTE, setLLMPluginVersion } from './constants';
 import { HealthCheckResponse, OpenAIHealthDetails } from './types';
@@ -349,7 +350,7 @@ export function streamChatCompletions(
   const channel: LiveChannelAddress = {
     scope: LiveChannelScope.Plugin,
     namespace: LLM_PLUGIN_ID,
-    path: OPENAI_CHAT_COMPLETIONS_PATH + '/' + self.crypto.randomUUID(),
+    path: OPENAI_CHAT_COMPLETIONS_PATH + '/' + uuidv4(),
     data: request,
   };
   const messages = getGrafanaLiveSrv()


### PR DESCRIPTION
crypto.randomUUID() is only available if the Grafana instance is using
HTTPS, which may not be the case for many on-prem users who do not want
to set up certs when running in a local network. Using the uuid module
instead will allow the stream completions to still work in these
environments, and there is nothing that requires crypto for creating a
path.