### PR TITLE
chore: relax version specifiers in frontend library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22324,13 +22324,13 @@
       "version": "0.10.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/data": "10.4.0",
-        "@grafana/runtime": "10.4.0",
-        "react": "18.3.1",
+        "@grafana/data": "^10.4.0 ||^11",
+        "@grafana/runtime": "^10.4.0 || ^11",
+        "react": "^18",
         "react-use": "17.5.0",
-        "rxjs": "7.8.1",
-        "semver": "7.6.3",
-        "uuid": "10.0.0"
+        "rxjs": "^7.8.1",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",

--- a/packages/grafana-llm-frontend/package.json
+++ b/packages/grafana-llm-frontend/package.json
@@ -42,12 +42,12 @@
     "typescript": "5.6.2"
   },
   "dependencies": {
-    "@grafana/data": "10.4.0",
-    "@grafana/runtime": "10.4.0",
-    "react": "18.3.1",
-    "react-use": "17.5.0",
-    "rxjs": "7.8.1",
-    "semver": "7.6.3",
-    "uuid": "10.0.0"
+    "@grafana/data": "^10.4.0 ||^11",
+    "@grafana/runtime": "^10.4.0 || ^11",
+    "react": "^18",
+    "react-use": "^17.5.0",
+    "rxjs": "^7.8.1",
+    "semver": "^7.6.3",
+    "uuid": "^10.0.0"
   }
 }


### PR DESCRIPTION
We're a library, so we shouldn't specify exact versions of things,
or downstream users may end up with multiple versions of a dependency
(e.g. React).
