### PR TITLE
chore: move Grafana, React and rxjs to peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15965,22 +15965,28 @@
       "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/data": "^10.4.0 ||^11",
-        "@grafana/runtime": "^10.4.0 || ^11",
-        "react": "^18",
         "react-use": "^17.6.0",
-        "rxjs": "^7.8.1",
         "semver": "^7.6.3",
         "uuid": "^11.0.5"
       },
       "devDependencies": {
+        "@grafana/data": "^10.4.0 ||^11",
+        "@grafana/runtime": "^10.4.0 || ^11",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@types/uuid": "^10.0.0",
+        "react": "^18",
         "rollup": "^4.30.1",
         "rollup-plugin-dts": "^6.1.1",
         "rollup-plugin-esbuild": "^6.1.1",
         "rollup-plugin-node-externals": "^8.0.0",
+        "rxjs": "^7.8.1",
         "typescript": "5.6.2"
+      },
+      "peerDependencies": {
+        "@grafana/data": "^10.4.0 ||^11",
+        "@grafana/runtime": "^10.4.0 || ^11",
+        "react": "^18",
+        "rxjs": "^7.8.1"
       }
     }
   }

--- a/packages/grafana-llm-frontend/package.json
+++ b/packages/grafana-llm-frontend/package.json
@@ -33,21 +33,27 @@
   "author": "Grafana",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@grafana/data": "^10.4.0 ||^11",
+    "@grafana/runtime": "^10.4.0 || ^11",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@types/uuid": "^10.0.0",
+    "react": "^18",
     "rollup": "^4.30.1",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-esbuild": "^6.1.1",
     "rollup-plugin-node-externals": "^8.0.0",
+    "rxjs": "^7.8.1",
     "typescript": "5.6.2"
   },
   "dependencies": {
+    "react-use": "^17.6.0",
+    "semver": "^7.6.3",
+    "uuid": "^11.0.5"
+  },
+  "peerDependencies": {
     "@grafana/data": "^10.4.0 ||^11",
     "@grafana/runtime": "^10.4.0 || ^11",
     "react": "^18",
-    "react-use": "^17.6.0",
-    "rxjs": "^7.8.1",
-    "semver": "^7.6.3",
-    "uuid": "^11.0.5"
+    "rxjs": "^7.8.1"
   }
 }


### PR DESCRIPTION
Grafana will provide them separately in the bundle so they
don't need to be direct dependencies. Include them in dev
dependencies for development, though.
