### PR TITLE
Configs: Add custom API as an separate option

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/provider.go
@@ -6,6 +6,8 @@ func createProvider(settings *Settings) (LLMProvider, error) {
 	switch settings.OpenAI.Provider {
 	case openAIProviderOpenAI:
 		return NewOpenAIProvider(settings.OpenAI, settings.Models)
+	case openAIProviderCustom:
+		return NewOpenAIProvider(settings.OpenAI, settings.Models)
 	case openAIProviderAzure:
 		return NewAzureProvider(settings.OpenAI, settings.Models.Default)
 	case openAIProviderGrafana:

--- a/packages/grafana-llm-app/pkg/plugin/provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/provider.go
@@ -4,9 +4,7 @@ import "errors"
 
 func createProvider(settings *Settings) (LLMProvider, error) {
 	switch settings.OpenAI.Provider {
-	case openAIProviderOpenAI:
-		return NewOpenAIProvider(settings.OpenAI, settings.Models)
-	case openAIProviderCustom:
+	case openAIProviderOpenAI, openAIProviderCustom:
 		return NewOpenAIProvider(settings.OpenAI, settings.Models)
 	case openAIProviderAzure:
 		return NewAzureProvider(settings.OpenAI, settings.Models.Default)

--- a/packages/grafana-llm-app/pkg/plugin/settings.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings.go
@@ -58,9 +58,7 @@ func (s OpenAISettings) Configured() bool {
 	}
 
 	switch s.Provider {
-	case openAIProviderGrafana:
-		return true
-	case openAIProviderTest:
+	case openAIProviderGrafana, openAIProviderCustom, openAIProviderTest:
 		return true
 	case openAIProviderAzure:
 		// Require some mappings for use with Azure.
@@ -71,8 +69,6 @@ func (s OpenAISettings) Configured() bool {
 		fallthrough
 	case openAIProviderOpenAI:
 		return s.apiKey != ""
-	case openAIProviderCustom:
-		return true
 	}
 	// Unknown or empty provider means configuration needs to be updated.
 	return false

--- a/packages/grafana-llm-app/pkg/plugin/settings.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings.go
@@ -20,6 +20,7 @@ type openAIProvider string
 const (
 	openAIProviderOpenAI  openAIProvider = "openai"
 	openAIProviderAzure   openAIProvider = "azure"
+	openAIProviderCustom  openAIProvider = "custom"
 	openAIProviderGrafana openAIProvider = "grafana" // via llm-gateway
 	openAIProviderTest    openAIProvider = "test"
 )
@@ -70,6 +71,8 @@ func (s OpenAISettings) Configured() bool {
 		fallthrough
 	case openAIProviderOpenAI:
 		return s.apiKey != ""
+	case openAIProviderCustom:
+		return true
 	}
 	// Unknown or empty provider means configuration needs to be updated.
 	return false
@@ -173,6 +176,7 @@ func loadSettings(appSettings backend.AppInstanceSettings) (*Settings, error) {
 	switch settings.OpenAI.Provider {
 	case openAIProviderOpenAI:
 	case openAIProviderAzure:
+	case openAIProviderCustom:
 	case openAIProviderGrafana:
 		if settings.LLMGateway.URL == "" {
 			// llm-gateway not available, this provider is invalid so switch to disabled

--- a/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
@@ -11,7 +11,7 @@ import { OpenAIConfig, OpenAIProvider } from './OpenAI';
 import { OpenAILogo } from './OpenAILogo';
 
 // LLMOptions are the 3 possible UI options for LLMs (grafana-provided cloud-only).
-export type LLMOptions = 'grafana-provided' | 'openai' | 'test' | 'disabled' | 'unconfigured';
+export type LLMOptions = 'grafana-provided' | 'openai' | 'test' | 'disabled' | 'unconfigured' | 'custom';
 
 // This maps the current settings to decide what UI selection (LLMOptions) to show
 function getLLMOptionFromSettings(settings: AppPluginSettings): LLMOptions {
@@ -23,6 +23,8 @@ function getLLMOptionFromSettings(settings: AppPluginSettings): LLMOptions {
     case 'azure':
     case 'openai':
       return 'openai';
+    case 'custom':
+      return 'custom';
     case 'test':
       return 'test';
     case 'grafana':
@@ -110,6 +112,12 @@ export function LLMConfig({
         onChange({ ...settings, openAI: { provider: 'openai', disabled: false } });
         setPreviousOpenAIProvider(undefined);
       }
+    }
+  };
+
+  const selectCustom = () => {
+    if (llmOption !== 'custom') {
+      onChange({ ...settings, openAI: { provider: 'custom', disabled: false } });
     }
   };
 
@@ -219,7 +227,7 @@ export function LLMConfig({
           <Card isSelected={llmOption === 'openai'} className={s.cardWithoutBottomMargin}>
             <Card.Heading>Use OpenAI-compatible API</Card.Heading>
             <Card.Description>
-              Enable LLM features in Grafana using an OpenAI-compatible API
+              Enable LLM features in Grafana using OpenAI API
               {llmOption === 'openai' && (
                 <OpenAIConfig
                   settings={settings.openAI ?? {}}
@@ -232,6 +240,26 @@ export function LLMConfig({
             </Card.Description>
             <Card.Figure>
               <OpenAILogo width={20} height={20} />
+            </Card.Figure>
+          </Card>
+        </div>
+        <div onClick={selectCustom}>
+          <Card isSelected={llmOption === 'custom'} className={s.cardWithoutBottomMargin}>
+            <Card.Heading>Use a Custom API</Card.Heading>
+            <Card.Description>
+              Enable LLM features in Grafana using a custom API (with "OpenAI-like" signature)
+              {llmOption === 'custom' && (
+                <OpenAIConfig
+                  settings={settings.openAI ?? {}}
+                  onChange={(openAI) => onChange({ ...settings, openAI })}
+                  secrets={secrets}
+                  secretsSet={secretsSet}
+                  onChangeSecrets={onChangeSecrets}
+                />
+              )}
+            </Card.Description>
+            <Card.Figure>
+              <Icon name="ai" size="lg" />
             </Card.Figure>
           </Card>
         </div>
@@ -251,7 +279,7 @@ export function LLMConfig({
           </Card.Figure>
         </Card>
       </FieldSet>
-      {llmOption === 'openai' && (
+      {(llmOption === 'openai' || llmOption === 'custom') && (
         <FieldSet label="Models" className={s.sidePadding}>
           <ModelConfig
             provider={settings.openAI?.provider ?? 'openai'}

--- a/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
@@ -227,7 +227,7 @@ export function LLMConfig({
           <Card isSelected={llmOption === 'openai'} className={s.cardWithoutBottomMargin}>
             <Card.Heading>Use OpenAI-compatible API</Card.Heading>
             <Card.Description>
-              Enable LLM features in Grafana using OpenAI API
+              Enable LLM features in Grafana using OpenAI-compatible API
               {llmOption === 'openai' && (
                 <OpenAIConfig
                   settings={settings.openAI ?? {}}
@@ -247,7 +247,7 @@ export function LLMConfig({
           <Card isSelected={llmOption === 'custom'} className={s.cardWithoutBottomMargin}>
             <Card.Heading>Use a Custom API</Card.Heading>
             <Card.Description>
-              Enable LLM features in Grafana using a custom API (with "OpenAI-like" signature)
+              {"Enable LLM features in Grafana using a custom API (with \"OpenAI-like\" signature)"}
               {llmOption === 'custom' && (
                 <OpenAIConfig
                   settings={settings.openAI ?? {}}

--- a/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
@@ -8,7 +8,7 @@ import { testIds } from 'components/testIds';
 import { getStyles, Secrets, SecretsSet } from './AppConfig';
 import { AzureModelDeploymentConfig, AzureModelDeployments } from './AzureConfig';
 
-export type OpenAIProvider = 'openai' | 'azure' | 'grafana' | 'test';
+export type OpenAIProvider = 'openai' | 'azure' | 'grafana' | 'test' | 'custom';
 
 export interface OpenAISettings {
   // The URL to reach OpenAI.
@@ -45,22 +45,35 @@ export function OpenAIConfig({
         event.currentTarget.type === 'checkbox' ? event.currentTarget.checked : event.currentTarget.value.trim(),
     });
   };
+
+  // Update settings when provider changes, set default URL for OpenAI
+  const onChangeProvider = (value: OpenAIProvider) => {
+    onChange({
+      ...settings,
+      provider: value,
+      url: value === 'openai' ? 'https://api.openai.com' : '',
+    });
+  };
+
   return (
     <FieldSet>
-      <Field label="Provider">
+      {settings.provider !== 'custom' && 
+        <Field label="Provider">
         <Select
           data-testid={testIds.appConfig.openAIProvider}
           options={
             [
-              { label: 'OpenAI/OpenAI Compatible', value: 'openai' },
+              { label: 'OpenAI', value: 'openai' },
               { label: 'Azure OpenAI', value: 'azure' },
             ] as Array<SelectableValue<OpenAIProvider>>
           }
           value={settings.provider ?? 'openai'}
-          onChange={(e) => onChange({ ...settings, provider: e.value })}
+          onChange={(e) => onChangeProvider(e.value as OpenAIProvider)}
           width={60}
         />
       </Field>
+    }
+
       <Field
         label={settings.provider === 'azure' ? 'Azure OpenAI Language API Endpoint' : 'API URL'}
         className={s.marginTop}
@@ -69,11 +82,16 @@ export function OpenAIConfig({
           width={60}
           name="url"
           data-testid={testIds.appConfig.openAIUrl}
-          value={settings.url}
+          value={settings.provider === 'openai' ? 'https://api.openai.com' : settings.url}
           placeholder={
-            settings.provider === 'azure' ? `https://<resource-name>.openai.azure.com` : `https://api.openai.com`
+            settings.provider === 'azure' 
+              ? `https://<resource-name>.openai.azure.com` 
+              : settings.provider === 'openai'
+                ? `https://api.openai.com`
+                : `https://llm.domain.com`
           }
           onChange={onChangeField}
+          disabled={settings.provider === 'openai'}
         />
       </Field>
 
@@ -92,7 +110,7 @@ export function OpenAIConfig({
         />
       </Field>
 
-      {settings.provider !== 'azure' && (
+      {settings.provider === 'openai' && (
         <Field label="API Organization ID">
           <Input
             width={60}

--- a/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
@@ -8,6 +8,9 @@ import { testIds } from 'components/testIds';
 import { getStyles, Secrets, SecretsSet } from './AppConfig';
 import { AzureModelDeploymentConfig, AzureModelDeployments } from './AzureConfig';
 
+const OPENAI_API_URL = 'https://api.openai.com';
+const AZURE_OPENAI_URL_TEMPLATE = 'https://<resource-name>.openai.azure.com';
+
 export type OpenAIProvider = 'openai' | 'azure' | 'grafana' | 'test' | 'custom';
 
 export interface OpenAISettings {
@@ -51,7 +54,7 @@ export function OpenAIConfig({
     onChange({
       ...settings,
       provider: value,
-      url: value === 'openai' ? 'https://api.openai.com' : '',
+      url: value === 'openai' ? OPENAI_API_URL : '',
     });
   };
 
@@ -82,12 +85,12 @@ export function OpenAIConfig({
           width={60}
           name="url"
           data-testid={testIds.appConfig.openAIUrl}
-          value={settings.provider === 'openai' ? 'https://api.openai.com' : settings.url}
+          value={settings.provider === 'openai' ? OPENAI_API_URL : settings.url}
           placeholder={
             settings.provider === 'azure' 
-              ? `https://<resource-name>.openai.azure.com` 
+              ? AZURE_OPENAI_URL_TEMPLATE
               : settings.provider === 'openai'
-                ? `https://api.openai.com`
+                ? OPENAI_API_URL
                 : `https://llm.domain.com`
           }
           onChange={onChangeField}


### PR DESCRIPTION
Currently the plugin supports custom API. However, the UI is not very clear.

Extract the "OpenAI compatible" setup logic to it's own "Custom API" card.

uses "OpenAI-like" to describe the API signature to make it more clear that it's not OpenAI