### PR TITLE
Abstract provider configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Each package has its own package.json with its own npm commands, but the intenti
 3. Run `npm install`
 4. Run `npm run dev`
 5. In a separate terminal from dev, run `npm run server`
-If you want to bring up the vector services, you can run `COMPOSE_PROFILES=vector yarn run server` instead
+If you want to bring up the vector services, you can run `COMPOSE_PROFILES=vector npm run server` instead
 
 6. Go to (http://localhost:3000/plugins/grafana-llm-app) to see configuration page and the developer sandbox
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15941,7 +15941,7 @@
         "webpack-livereload-plugin": "^3.0.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "packages/grafana-llm-app/node_modules/react-dom": {

--- a/packages/grafana-llm-app/README.md
+++ b/packages/grafana-llm-app/README.md
@@ -121,15 +121,15 @@ The vector services of the plugin allow some AI-based features (initially, the P
 apps:
   - type: grafana-llm-app
     jsonData:
+      provider: openai
       openAI:
-        provider: openai
         url: https://api.openai.com
         organizationId: $OPENAI_ORGANIZATION_ID
+      # provider: azure
       # openAI:
-        # provider: azure
-        # url: https://<resource>.openai.azure.com
-        # azureModelMapping:
-        #   - ["gpt-3.5-turbo", "gpt-35-turbo"]
+      #   url: https://<resource>.openai.azure.com
+      #   azureModelMapping:
+      #     - ["gpt-3.5-turbo", "gpt-35-turbo"]
       vector:
         enabled: true
         model: BAAI/bge-small-en-v1.5

--- a/packages/grafana-llm-app/pkg/plugin/health.go
+++ b/packages/grafana-llm-app/pkg/plugin/health.go
@@ -97,7 +97,7 @@ func (a *App) openAIHealth(ctx context.Context) (openAIHealthDetails, error) {
 
 	d := openAIHealthDetails{
 		OK:         true,
-		Configured: a.settings.OpenAI.Configured(),
+		Configured: a.settings.Configured(),
 		Models:     map[Model]openAIModelHealth{},
 		Assistant:  openAIModelHealth{OK: false, Error: "Assistant not available"},
 	}

--- a/packages/grafana-llm-app/pkg/plugin/health.go
+++ b/packages/grafana-llm-app/pkg/plugin/health.go
@@ -87,7 +87,7 @@ func (a *App) openAIHealth(ctx context.Context) (openAIHealthDetails, error) {
 	}
 
 	// If OpenAI is disabled it has been configured but cannot be queried.
-	if a.settings.OpenAI.Disabled {
+	if a.settings.Disabled {
 		return openAIHealthDetails{
 			OK:         false,
 			Configured: true,

--- a/packages/grafana-llm-app/pkg/plugin/health_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/health_test.go
@@ -83,8 +83,8 @@ func TestCheckHealth(t *testing.T) {
 			settings: backend.AppInstanceSettings{
 				DecryptedSecureJSONData: map[string]string{},
 				JSONData: json.RawMessage(`{
+					"disabled": true,
 					"openai": {
-						"disabled": true,
 						"url": "%s"
 					}
 				}`),

--- a/packages/grafana-llm-app/pkg/plugin/provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/provider.go
@@ -3,16 +3,18 @@ package plugin
 import "errors"
 
 func createProvider(settings *Settings) (LLMProvider, error) {
-	switch settings.OpenAI.Provider {
-	case openAIProviderOpenAI, openAIProviderCustom:
+	provider := settings.getEffectiveProvider()
+
+	switch provider {
+	case ProviderTypeOpenAI, ProviderTypeCustom:
 		return NewOpenAIProvider(settings.OpenAI, settings.Models)
-	case openAIProviderAzure:
+	case ProviderTypeAzure:
 		return NewAzureProvider(settings.OpenAI, settings.Models.Default)
-	case openAIProviderGrafana:
+	case ProviderTypeGrafana:
 		return NewGrafanaProvider(*settings)
-	case openAIProviderTest:
+	case ProviderTypeTest:
 		return &settings.OpenAI.TestProvider, nil
 	default:
-		return nil, errors.New("Invalid OpenAI Provider supplied")
+		return nil, errors.New("Invalid Provider configuration")
 	}
 }

--- a/packages/grafana-llm-app/pkg/plugin/resources_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/resources_test.go
@@ -218,7 +218,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			settings: Settings{
 				OpenAI: OpenAISettings{
 					OrganizationID: "myOrg",
-					Provider:       openAIProviderOpenAI,
+					Provider:       ProviderTypeOpenAI,
 				},
 			},
 			apiKey: "abcd1234",
@@ -242,7 +242,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			settings: Settings{
 				OpenAI: OpenAISettings{
 					OrganizationID: "myOrg",
-					Provider:       openAIProviderOpenAI,
+					Provider:       ProviderTypeOpenAI,
 				},
 			},
 			apiKey: "abcd1234",
@@ -266,7 +266,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			settings: Settings{
 				OpenAI: OpenAISettings{
 					OrganizationID: "myOrg",
-					Provider:       openAIProviderOpenAI,
+					Provider:       ProviderTypeOpenAI,
 				},
 			},
 			apiKey: "abcd1234",
@@ -294,7 +294,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			settings: Settings{
 				OpenAI: OpenAISettings{
 					OrganizationID: "myOrg",
-					Provider:       openAIProviderOpenAI,
+					Provider:       ProviderTypeOpenAI,
 				},
 			},
 			apiKey: "abcd1234",
@@ -322,7 +322,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			settings: Settings{
 				OpenAI: OpenAISettings{
 					OrganizationID: "myOrg",
-					Provider:       openAIProviderAzure,
+					Provider:       ProviderTypeAzure,
 					AzureMapping: [][]string{
 						{"gpt-3.5-turbo", "gpt-35-turbo"},
 					},
@@ -350,7 +350,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			settings: Settings{
 				OpenAI: OpenAISettings{
 					OrganizationID: "myOrg",
-					Provider:       openAIProviderAzure,
+					Provider:       ProviderTypeAzure,
 					AzureMapping: [][]string{
 						{"gpt-3.5-turbo", "gpt-35-turbo"},
 					},
@@ -378,7 +378,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			settings: Settings{
 				OpenAI: OpenAISettings{
 					OrganizationID: "myOrg",
-					Provider:       openAIProviderAzure,
+					Provider:       ProviderTypeAzure,
 					AzureMapping: [][]string{
 						{"gpt-3.5-turbo", "gpt-35-turbo"},
 					},
@@ -406,7 +406,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			settings: Settings{
 				OpenAI: OpenAISettings{
 					OrganizationID: "myOrg",
-					Provider:       openAIProviderAzure,
+					Provider:       ProviderTypeAzure,
 					AzureMapping: [][]string{
 						{"gpt-3.5-turbo", "gpt-35-turbo"},
 					},
@@ -430,7 +430,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 				Tenant:           "123",
 				GrafanaComAPIKey: "abcd1234",
 				OpenAI: OpenAISettings{
-					Provider: openAIProviderGrafana,
+					Provider: ProviderTypeGrafana,
 				},
 			},
 			apiKey: "abcd1234",
@@ -455,7 +455,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 				Tenant:           "123",
 				GrafanaComAPIKey: "abcd1234",
 				OpenAI: OpenAISettings{
-					Provider: openAIProviderGrafana,
+					Provider: ProviderTypeGrafana,
 				},
 			},
 			apiKey: "abcd1234",
@@ -480,7 +480,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 				Tenant:           "123",
 				GrafanaComAPIKey: "abcd1234",
 				OpenAI: OpenAISettings{
-					Provider: openAIProviderGrafana,
+					Provider: ProviderTypeGrafana,
 				},
 			},
 			apiKey: "abcd1234",
@@ -505,7 +505,7 @@ func TestCallOpenAIProxy(t *testing.T) {
 			server := newMockOpenAIServer()
 
 			// Update the OpenAI/LLMGateway URL with the mock server's URL.
-			if tc.settings.OpenAI.Provider == openAIProviderGrafana {
+			if tc.settings.OpenAI.Provider == ProviderTypeGrafana {
 				// Make sure our tests work when the LLM gateway is at a subpath.
 				tc.settings.LLMGateway.URL = server.server.URL + "/llm"
 			} else {

--- a/packages/grafana-llm-app/pkg/plugin/settings.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings.go
@@ -53,16 +53,6 @@ type OpenAISettings struct {
 	TestProvider testProvider `json:"testProvider,omitempty"`
 }
 
-// AnthropicSettings contains Anthropic-specific settings
-type AnthropicSettings struct {
-	// The URL to the provider's API
-	URL string `json:"url"`
-
-	// apiKey is the provider-specific API key needed to authenticate requests
-	// Stored securely.
-	apiKey string
-}
-
 // Configured returns whether the provider has been configured
 func (s *Settings) Configured() bool {
 	// If disabled has been selected than the provider has been configured.
@@ -156,9 +146,6 @@ type Settings struct {
 	// OpenAI related settings
 	OpenAI OpenAISettings `json:"openAI"`
 
-	// Anthropic related settings
-	Anthropic AnthropicSettings `json:"anthropic"`
-
 	// VectorDB settings. May rely on OpenAI settings.
 	Vector vector.VectorSettings `json:"vector"`
 
@@ -191,9 +178,6 @@ func loadSettings(appSettings backend.AppInstanceSettings) (*Settings, error) {
 	if settings.OpenAI.URL == "" {
 		settings.OpenAI.URL = "https://api.openai.com"
 	}
-	if settings.Anthropic.URL == "" {
-		settings.Anthropic.URL = "https://api.anthropic.com"
-	}
 	if settings.Vector.Embed.Type == embed.EmbedderOpenAI {
 		settings.Vector.Embed.OpenAI.URL = settings.OpenAI.URL
 		settings.Vector.Embed.OpenAI.AuthType = "openai-key-auth"
@@ -223,7 +207,6 @@ func loadSettings(appSettings backend.AppInstanceSettings) (*Settings, error) {
 	settings.DecryptedSecureJSONData = appSettings.DecryptedSecureJSONData
 
 	settings.OpenAI.apiKey = settings.DecryptedSecureJSONData[openAIKey]
-	settings.Anthropic.apiKey = settings.DecryptedSecureJSONData["anthropicKey"]
 
 	// TenantID and GrafanaCom token are combined as "tenantId:GComToken" and base64 encoded, the following undoes that.
 	encodedTenantAndToken := settings.DecryptedSecureJSONData[encodedTenantAndTokenKey]

--- a/packages/grafana-llm-app/pkg/plugin/settings_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings_test.go
@@ -160,9 +160,7 @@ func TestConfigured(t *testing.T) {
 		{
 			testName: "disabled",
 			settings: Settings{
-				OpenAI: OpenAISettings{
-					Disabled: true,
-				},
+				Disabled: true,
 			},
 			configured: true,
 		},
@@ -170,9 +168,7 @@ func TestConfigured(t *testing.T) {
 			testName: "disabled with otherwise valid configuration",
 			settings: Settings{
 				Provider: ProviderTypeGrafana,
-				OpenAI: OpenAISettings{
-					Disabled: true,
-				},
+				Disabled: true,
 			},
 			configured: true,
 		},

--- a/packages/grafana-llm-app/pkg/plugin/stream_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/stream_test.go
@@ -85,7 +85,7 @@ func TestRunStream(t *testing.T) {
 	}{
 		{
 			name:       "bad auth",
-			settings:   Settings{OpenAI: OpenAISettings{Provider: openAIProviderOpenAI}},
+			settings:   Settings{OpenAI: OpenAISettings{Provider: ProviderTypeOpenAI}},
 			statusCode: http.StatusUnauthorized,
 
 			expErr:          "401",
@@ -94,7 +94,7 @@ func TestRunStream(t *testing.T) {
 		{
 			name: "grafana managed key",
 			settings: Settings{
-				OpenAI: OpenAISettings{Provider: openAIProviderGrafana},
+				OpenAI: OpenAISettings{Provider: ProviderTypeGrafana},
 			},
 			statusCode: http.StatusUnauthorized,
 
@@ -103,7 +103,7 @@ func TestRunStream(t *testing.T) {
 		},
 		{
 			name:        "happy path",
-			settings:    Settings{OpenAI: OpenAISettings{Provider: openAIProviderOpenAI}},
+			settings:    Settings{OpenAI: OpenAISettings{Provider: ProviderTypeOpenAI}},
 			statusCode:  http.StatusOK,
 			includeDone: true,
 
@@ -112,7 +112,7 @@ func TestRunStream(t *testing.T) {
 		},
 		{
 			name:       "happy path without EOF",
-			settings:   Settings{OpenAI: OpenAISettings{Provider: openAIProviderOpenAI}},
+			settings:   Settings{OpenAI: OpenAISettings{Provider: ProviderTypeOpenAI}},
 			statusCode: http.StatusOK,
 
 			expErr:          "",
@@ -128,7 +128,7 @@ func TestRunStream(t *testing.T) {
 
 			// Initialize app (need to set OpenAISettings:URL in here)
 			settings := tc.settings
-			if settings.OpenAI.Provider == openAIProviderGrafana {
+			if settings.OpenAI.Provider == ProviderTypeGrafana {
 				settings.LLMGateway.URL = server.server.URL
 			} else {
 				settings.OpenAI.URL = server.server.URL

--- a/packages/grafana-llm-app/provisioning/plugins/grafana-vector-api/grafana-llm-app.yaml
+++ b/packages/grafana-llm-app/provisioning/plugins/grafana-vector-api/grafana-llm-app.yaml
@@ -6,16 +6,16 @@ apps:
       base64EncodedAccessTokenSet: True
       # enableGrafanaManagedLLM: True
       # displayVectorStoreOptions: False
+      provider: openai
       openAI:
-        provider: openai
         url: https://api.openai.com
         organizationId: $OPENAI_ORGANIZATION_ID
+      # provider: azure
       # openAI:
-        # provider: azure
-        # url: https://<resource>.openai.azure.com
-        # azureModelMapping:
-        #   - ["base", "gpt-35-turbo"]
-        #   - ["large", "gpt-4-turbo"]
+      #   url: https://<resource>.openai.azure.com
+      #   azureModelMapping:
+      #     - ["base", "gpt-35-turbo"]
+      #     - ["large", "gpt-4-turbo"]
       vector:
         enabled: true
         model: BAAI/bge-small-en-v1.5

--- a/packages/grafana-llm-app/provisioning/plugins/openai-qdrant/grafana-llm-app.yaml
+++ b/packages/grafana-llm-app/provisioning/plugins/openai-qdrant/grafana-llm-app.yaml
@@ -3,8 +3,8 @@ apiVersion: 1
 apps:
   - type: grafana-llm-app
     jsonData:
+      provider: openai
       openAI:
-        provider: openai
         url: https://api.openai.com
         organizationId: $OPENAI_ORGANIZATION_ID
       vector:

--- a/packages/grafana-llm-app/provisioning/plugins/test-provider/grafana-llm-app.yaml
+++ b/packages/grafana-llm-app/provisioning/plugins/test-provider/grafana-llm-app.yaml
@@ -6,10 +6,8 @@ apps:
       base64EncodedAccessTokenSet: True
       # enableGrafanaManagedLLM: True
       # displayVectorStoreOptions: False
+      provider: test
       openAI:
-        provider: test
-        # url: https://api.openai.com
-        # organizationId: $OPENAI_ORGANIZATION_ID
         testProvider:
           modelsResponse: 
             data:

--- a/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
@@ -14,17 +14,11 @@ import { OpenAISettings } from './OpenAI';
 import { VectorConfig, VectorSettings } from './Vector';
 ///////////////////////
 
-interface AnthropicSettings {
-  url?: string;
-  apiKey?: string;
-}
-
 export type ProviderType = 'openai' | 'azure' | 'grafana' | 'test' | 'custom';
 
 export interface AppPluginSettings {
   provider?: ProviderType;
   disabled?: boolean;
-  anthropic?: AnthropicSettings;
   openAI?: OpenAISettings;
   vector?: VectorSettings;
   models?: ModelSettings;

--- a/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
@@ -16,7 +16,6 @@ import { VectorConfig, VectorSettings } from './Vector';
 
 interface AnthropicSettings {
   url?: string;
-  disabled?: boolean;
   apiKey?: string;
 }
 
@@ -24,6 +23,7 @@ export type ProviderType = 'openai' | 'azure' | 'grafana' | 'test' | 'custom';
 
 export interface AppPluginSettings {
   provider?: ProviderType;
+  disabled?: boolean;
   anthropic?: AnthropicSettings;
   openAI?: OpenAISettings;
   vector?: VectorSettings;

--- a/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
@@ -14,7 +14,17 @@ import { OpenAISettings } from './OpenAI';
 import { VectorConfig, VectorSettings } from './Vector';
 ///////////////////////
 
+interface AnthropicSettings {
+  url?: string;
+  disabled?: boolean;
+  apiKey?: string;
+}
+
+export type ProviderType = 'openai' | 'azure' | 'grafana' | 'test' | 'custom';
+
 export interface AppPluginSettings {
+  provider?: ProviderType;
+  anthropic?: AnthropicSettings;
   openAI?: OpenAISettings;
   vector?: VectorSettings;
   models?: ModelSettings;
@@ -46,6 +56,16 @@ function initialSecrets(secureJsonFields: KeyValue<boolean>): SecretsSet {
 
 export interface AppConfigProps extends PluginConfigPageProps<AppPluginMeta<AppPluginSettings>> {}
 
+// Helper function to get the effective provider, handling both legacy and new provider fields
+export function getEffectiveProvider(settings: AppPluginSettings): ProviderType | undefined {
+  // If the root provider is set, use it (new format)
+  if (settings.provider) {
+    return settings.provider;
+  }
+  // Otherwise fall back to the legacy openAI.provider field
+  return settings.openAI?.provider;
+}
+
 export const AppConfig = ({ plugin }: AppConfigProps) => {
   const s = useStyles2(getStyles);
   const { enabled, pinned, jsonData, secureJsonFields } = plugin.meta;
@@ -63,7 +83,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
 
   const validateInputs = (): string | undefined => {
     // Check if Grafana-provided OpenAI enabled, that it has been opted-in
-    if (settings?.openAI?.provider === 'grafana' && !managedLLMOptIn) {
+    if (settings?.provider === 'grafana' && !managedLLMOptIn) {
       return 'You must click the "I Accept" checkbox to use OpenAI provided by Grafana';
     }
     return;
@@ -103,11 +123,18 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
         secureJsonData[key] = newSecrets[key];
       }
     }
+
+    // Migrate the provider to the new format before saving
+    const settingsToSave = {
+      ...settings,
+      provider: getEffectiveProvider(settings),
+    };
+
     try {
       await updateAndSavePluginSettings(plugin.meta.id, settings.enableGrafanaManagedLLM, {
         enabled,
         pinned,
-        jsonData: settings,
+        jsonData: settingsToSave,
         secureJsonData,
       });
     } catch (e) {
@@ -117,7 +144,8 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
 
     // Note: health-check uses the state saved in the plugin settings.
     let healthCheckResult: HealthCheckResult | undefined = undefined;
-    if (settings.openAI?.provider !== undefined) {
+    const effectiveProvider = getEffectiveProvider(settings);
+    if (effectiveProvider !== undefined) {
       const result = await checkPluginHealth(plugin.meta.id);
       healthCheckResult = result.data;
     }
@@ -126,7 +154,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
     // If moving away from Grafana-managed LLM, opt-out of the feature automatically
     // This logic should only be triggered if the Grafana-managed LLM feature is enabled (Grafana Cloud Only)
     if (settings.enableGrafanaManagedLLM === true) {
-      if (managedLLMOptIn && settings.openAI?.provider !== 'grafana') {
+      if (managedLLMOptIn && effectiveProvider !== 'grafana') {
         await saveLLMOptInState(false);
       } else {
         await saveLLMOptInState(managedLLMOptIn);
@@ -134,7 +162,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
     }
 
     // Update the frontend settings explicitly, it is otherwise not updated until page reload
-    plugin.meta.jsonData = settings;
+    plugin.meta.jsonData = settingsToSave;
 
     setIsUpdating(false);
     setUpdated(false);

--- a/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
@@ -15,7 +15,8 @@ export type LLMOptions = 'grafana-provided' | 'openai' | 'test' | 'disabled' | '
 
 // This maps the current settings to decide what UI selection (LLMOptions) to show
 function getLLMOptionFromSettings(settings: AppPluginSettings): LLMOptions {
-  if (settings.openAI?.disabled === true) {
+  // Backwards compatibility for disabled field
+  if (settings.disabled || settings.openAI?.disabled) {
     return 'disabled';
   }
 
@@ -75,7 +76,7 @@ export function LLMConfig({
         setPreviousOpenAIProvider(settings.provider);
       }
 
-      onChange({ ...settings, provider: undefined, openAI: { ...settings.openAI, disabled: true } });
+      onChange({ ...settings, provider: undefined, disabled: true, openAI: { ...settings.openAI, disabled: true } });
     }
   };
 
@@ -86,7 +87,7 @@ export function LLMConfig({
         setPreviousOpenAIProvider(settings.provider);
       }
 
-      onChange({ ...settings, provider: 'test', openAI: { ...settings.openAI, disabled: false } });
+      onChange({ ...settings, provider: 'test', disabled: false, openAI: { ...settings.openAI, disabled: false } });
     }
   };
 
@@ -98,7 +99,7 @@ export function LLMConfig({
         setPreviousOpenAIProvider(settings.provider);
       }
 
-      onChange({ ...settings, provider: 'grafana', openAI: { disabled: false } });
+      onChange({ ...settings, provider: 'grafana', disabled: false, openAI: { disabled: false } });
     }
   };
 
@@ -108,10 +109,10 @@ export function LLMConfig({
       // If the previous provider was not a valid openAI vendor, default to openai
       // Otherwise the state would revert to the incorrect previous provider
       if (previousOpenAIProvider === 'openai' || previousOpenAIProvider === 'azure') {
-        onChange({ ...settings, provider: previousOpenAIProvider, openAI: { disabled: false } });
+        onChange({ ...settings, provider: previousOpenAIProvider, disabled: false, openAI: { disabled: false } });
         setPreviousOpenAIProvider(undefined);
       } else {
-        onChange({ ...settings, provider: 'openai', openAI: { disabled: false } });
+        onChange({ ...settings, provider: 'openai', disabled: false, openAI: { disabled: false } });
         setPreviousOpenAIProvider(undefined);
       }
     }
@@ -119,7 +120,7 @@ export function LLMConfig({
 
   const selectCustom = () => {
     if (llmOption !== 'custom') {
-      onChange({ ...settings, provider: 'custom', openAI: { disabled: false } });
+      onChange({ ...settings, provider: 'custom', disabled: false, openAI: { disabled: false } });
     }
   };
 

--- a/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
@@ -4,10 +4,10 @@ import React, { useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Button, Card, Checkbox, FieldSet, Icon, useStyles2 } from '@grafana/ui';
 
-import { AppPluginSettings, Secrets, SecretsSet } from './AppConfig';
+import { AppPluginSettings, Secrets, SecretsSet, ProviderType, getEffectiveProvider } from './AppConfig';
 import { ModelConfig } from './ModelConfig';
 import { DevSandbox } from './DevSandbox';
-import { OpenAIConfig, OpenAIProvider } from './OpenAI';
+import { OpenAIConfig } from './OpenAI';
 import { OpenAILogo } from './OpenAILogo';
 
 // LLMOptions are the 3 possible UI options for LLMs (grafana-provided cloud-only).
@@ -19,7 +19,9 @@ function getLLMOptionFromSettings(settings: AppPluginSettings): LLMOptions {
     return 'disabled';
   }
 
-  switch (settings.openAI?.provider) {
+  const provider = getEffectiveProvider(settings);
+
+  switch (provider) {
     case 'azure':
     case 'openai':
       return 'openai';
@@ -59,7 +61,7 @@ export function LLMConfig({
   const llmOption = getLLMOptionFromSettings(settings);
 
   // previousOpenAIProvider caches the value of the openAI provider, as it is overwritten by the grafana option
-  const [previousOpenAIProvider, setPreviousOpenAIProvider] = useState<OpenAIProvider>();
+  const [previousOpenAIProvider, setPreviousOpenAIProvider] = useState<ProviderType>();
 
   const optInChange = () => {
     setOptIn(!optIn);
@@ -70,10 +72,10 @@ export function LLMConfig({
     if (llmOption !== 'disabled') {
       // Cache if OpenAI or Azure provider is used, so can restore
       if (previousOpenAIProvider === undefined) {
-        setPreviousOpenAIProvider(settings.openAI?.provider);
+        setPreviousOpenAIProvider(settings.provider);
       }
 
-      onChange({ ...settings, openAI: { ...settings.openAI, provider: undefined, disabled: true } });
+      onChange({ ...settings, provider: undefined, openAI: { ...settings.openAI, disabled: true } });
     }
   };
 
@@ -81,10 +83,10 @@ export function LLMConfig({
     if (llmOption !== 'test') {
       // Cache if OpenAI or Azure provider is used, so can restore
       if (previousOpenAIProvider === undefined) {
-        setPreviousOpenAIProvider(settings.openAI?.provider);
+        setPreviousOpenAIProvider(settings.provider);
       }
 
-      onChange({ ...settings, openAI: { ...settings.openAI, provider: 'test', disabled: false } });
+      onChange({ ...settings, provider: 'test', openAI: { ...settings.openAI, disabled: false } });
     }
   };
 
@@ -93,10 +95,10 @@ export function LLMConfig({
     if (llmOption !== 'grafana-provided') {
       // Cache if OpenAI or Azure provider is used, so can restore
       if (previousOpenAIProvider === undefined) {
-        setPreviousOpenAIProvider(settings.openAI?.provider);
+        setPreviousOpenAIProvider(settings.provider);
       }
 
-      onChange({ ...settings, openAI: { provider: 'grafana', disabled: false } });
+      onChange({ ...settings, provider: 'grafana', openAI: { disabled: false } });
     }
   };
 
@@ -106,10 +108,10 @@ export function LLMConfig({
       // If the previous provider was not a valid openAI vendor, default to openai
       // Otherwise the state would revert to the incorrect previous provider
       if (previousOpenAIProvider === 'openai' || previousOpenAIProvider === 'azure') {
-        onChange({ ...settings, openAI: { provider: previousOpenAIProvider, disabled: false } });
+        onChange({ ...settings, provider: previousOpenAIProvider, openAI: { disabled: false } });
         setPreviousOpenAIProvider(undefined);
       } else {
-        onChange({ ...settings, openAI: { provider: 'openai', disabled: false } });
+        onChange({ ...settings, provider: 'openai', openAI: { disabled: false } });
         setPreviousOpenAIProvider(undefined);
       }
     }
@@ -117,7 +119,7 @@ export function LLMConfig({
 
   const selectCustom = () => {
     if (llmOption !== 'custom') {
-      onChange({ ...settings, openAI: { provider: 'custom', disabled: false } });
+      onChange({ ...settings, provider: 'custom', openAI: { disabled: false } });
     }
   };
 
@@ -282,7 +284,7 @@ export function LLMConfig({
       {(llmOption === 'openai' || llmOption === 'custom') && (
         <FieldSet label="Models" className={s.sidePadding}>
           <ModelConfig
-            provider={settings.openAI?.provider ?? 'openai'}
+            provider={settings.provider ?? 'openai'}
             settings={settings.models ?? { mapping: {} }}
             onChange={(models) => onChange({ ...settings, models })}
           />

--- a/packages/grafana-llm-app/src/components/AppConfig/ModelConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/ModelConfig.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Badge, Button, Divider, Field, FieldSet, Input, Label, Select } from '@grafana/ui';
 import { openai } from '@grafana/llm';
 
-import { OpenAIProvider } from './OpenAI';
+import { ProviderType } from './AppConfig';
 
 export type ModelMapping = Partial<Record<openai.Model, string>>;
 
@@ -50,7 +50,7 @@ export function ModelConfig({
   settings,
   onChange,
 }: {
-  provider: OpenAIProvider;
+  provider: ProviderType;
   settings: ModelSettings;
   onChange: (settings: ModelSettings) => void;
 }) {

--- a/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
@@ -5,13 +5,11 @@ import { Field, FieldSet, Input, SecretInput, Select, useStyles2 } from '@grafan
 
 import { SelectableValue } from '@grafana/data';
 import { testIds } from 'components/testIds';
-import { getStyles, Secrets, SecretsSet } from './AppConfig';
+import { getStyles, ProviderType, Secrets, SecretsSet } from './AppConfig';
 import { AzureModelDeploymentConfig, AzureModelDeployments } from './AzureConfig';
 
 const OPENAI_API_URL = 'https://api.openai.com';
 const AZURE_OPENAI_URL_TEMPLATE = 'https://<resource-name>.openai.azure.com';
-
-export type OpenAIProvider = 'openai' | 'azure' | 'grafana' | 'test' | 'custom';
 
 export interface OpenAISettings {
   // The URL to reach OpenAI.
@@ -19,7 +17,7 @@ export interface OpenAISettings {
   // The organization ID for OpenAI.
   organizationId?: string;
   // Whether to use Azure OpenAI.
-  provider?: OpenAIProvider;
+  provider?: ProviderType;
   // A mapping of OpenAI models to Azure deployment names.
   azureModelMapping?: AzureModelDeployments;
   // If the LLM features have been explicitly disabled.
@@ -50,7 +48,7 @@ export function OpenAIConfig({
   };
 
   // Update settings when provider changes, set default URL for OpenAI
-  const onChangeProvider = (value: OpenAIProvider) => {
+  const onChangeProvider = (value: ProviderType) => {
     onChange({
       ...settings,
       provider: value,
@@ -63,15 +61,15 @@ export function OpenAIConfig({
       {settings.provider !== 'custom' && 
         <Field label="Provider">
         <Select
-          data-testid={testIds.appConfig.openAIProvider}
+          data-testid={testIds.appConfig.provider}
           options={
             [
               { label: 'OpenAI', value: 'openai' },
               { label: 'Azure OpenAI', value: 'azure' },
-            ] as Array<SelectableValue<OpenAIProvider>>
+            ] as Array<SelectableValue<ProviderType>>
           }
           value={settings.provider ?? 'openai'}
-          onChange={(e) => onChangeProvider(e.value as OpenAIProvider)}
+          onChange={(e) => onChangeProvider(e.value as ProviderType)}
           width={60}
         />
       </Field>

--- a/packages/grafana-llm-app/src/components/testIds.ts
+++ b/packages/grafana-llm-app/src/components/testIds.ts
@@ -1,7 +1,7 @@
 export const testIds = {
   appConfig: {
     container: 'data-testid ac-container',
-    openAIProvider: 'data-testid ac-openai-provider',
+    provider: 'data-testid ac-provider',
     openAIKey: 'data-testid ac-openai-api-key',
     openAIOrganizationID: 'data-testid ac-openai-api-organization-id',
     openAIUrl: 'data-testid ac-openai-api-url',


### PR DESCRIPTION
This PR implements the foundational changes needed to support the Anthropic API integration (#504). It refactors the provider configuration infrastructure to handle multiple LLM providers in a more generic way.

### Key Changes
- Abstracts provider configuration by moving provider type to the top-level Settings struct
- Relocated `disabled` flag from OpenAI settings to top-level settings to make it provider-agnostic
- Adds initial AnthropicSettings struct with basic configuration fields (URL, API key)
- Maintains backward compatibility for existing OpenAI configurations

### Next Steps
-  Implement Anthropic provider client
- Add UI components for Anthropic configuration
- Add support for Anthropic model mappings
- Implement message streaming for Anthropic API
- Add tests for Anthropic provider

The changes maintain existing functionality while preparing for Anthropic support. All existing tests pass with the refactored provider configuration.

#504 (partially - this is the first step)