### PR TITLE
Add Anthropic Provider Support

### DIFF
--- a/packages/grafana-llm-app/README.md
+++ b/packages/grafana-llm-app/README.md
@@ -69,8 +69,8 @@ apps:
   - type: 'grafana-llm-app'
     disabled: false
     jsonData:
+      provider: azure
       openAI:
-        provider: azure
         url: https://<resource>.openai.azure.com
         azureModelMapping:
           - ["base", "gpt-35-turbo"]
@@ -85,6 +85,21 @@ where:
 - the `azureModelMapping` field contains `[model, deployment]` pairs so that features know
   which Azure deployment to use in place of each model you wish to be used.
 
+### Using Anthropic
+
+To provision the plugin to use Anthropic, use settings similar to this:
+
+```yaml
+apiVersion: 1
+
+apps:
+  - type: 'grafana-llm-app'
+    disabled: false
+    jsonData:
+      provider: anthropic
+    secureJsonData:
+      anthropicKey: $ANTHROPIC_API_KEY
+```
 
 ### Provisioning vector services
 

--- a/packages/grafana-llm-app/docker-compose.yaml
+++ b/packages/grafana-llm-app/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
       args:
         grafana_version: ${GRAFANA_VERSION:-main}
     environment:
+      ANTHROPIC_API_KEY: $ANTHROPIC_API_KEY
       AZURE_OPENAI_API_KEY: $AZURE_OPENAI_API_KEY
       GF_LOG_LEVEL: debug
       GF_SERVER_ROUTER_LOGGING: true

--- a/packages/grafana-llm-app/go.mod
+++ b/packages/grafana-llm-app/go.mod
@@ -5,6 +5,7 @@ go 1.22.7
 toolchain go1.23.3
 
 require (
+	github.com/anthropics/anthropic-sdk-go v0.2.0-alpha.10
 	github.com/grafana/grafana-plugin-sdk-go v0.263.0
 	github.com/qdrant/go-client v1.13.0
 	github.com/sashabaranov/go-openai v1.32.0
@@ -69,6 +70,10 @@ require (
 	github.com/prometheus/common v0.61.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/unknwon/bra v0.0.0-20200517080246-1e3013ecaff8 // indirect
 	github.com/unknwon/com v1.0.1 // indirect
 	github.com/unknwon/log v0.0.0-20150304194804-e617c87089d3 // indirect

--- a/packages/grafana-llm-app/go.sum
+++ b/packages/grafana-llm-app/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
+github.com/anthropics/anthropic-sdk-go v0.2.0-alpha.10 h1:myWicO7qECViRePrrsSijlakZK3q7vzHBCoS2hL+8V0=
+github.com/anthropics/anthropic-sdk-go v0.2.0-alpha.10/go.mod h1:GJxtdOs9K4neo8Gg65CjJ7jNautmldGli5/OFNabOoo=
 github.com/apache/arrow-go/v18 v18.0.1-0.20241212180703-82be143d7c30 h1:hXVi7QKuCQ0E8Yujfu9b0f0RnzZ72efpWvPnZgnJPrE=
 github.com/apache/arrow-go/v18 v18.0.1-0.20241212180703-82be143d7c30/go.mod h1:RNuWDIiGjq5nndL2PyQrndUy9nMLwheA3uWaAV7fe4U=
 github.com/apache/thrift v0.21.0 h1:tdPmh/ptjE1IJnhbhrcl2++TauVjy242rkV/UzJChnE=
@@ -186,6 +188,16 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/unknwon/bra v0.0.0-20200517080246-1e3013ecaff8 h1:aVGB3YnaS/JNfOW3tiHIlmNmTDg618va+eT0mVomgyI=

--- a/packages/grafana-llm-app/pkg/plugin/anthropic_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/anthropic_provider.go
@@ -1,0 +1,227 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/sashabaranov/go-openai"
+)
+
+type anthropicProvider struct {
+	settings AnthropicSettings
+	models   *ModelSettings
+	client   *anthropic.Client
+}
+
+func NewAnthropicProvider(settings AnthropicSettings, models *ModelSettings) (LLMProvider, error) {
+	httpClientOpts := option.WithHTTPClient(&http.Client{
+		Timeout: 2 * time.Minute,
+	})
+	client := anthropic.NewClient(
+		option.WithAPIKey(settings.apiKey),
+		httpClientOpts,
+	)
+
+	if settings.URL != "" {
+		client = anthropic.NewClient(
+			option.WithAPIKey(settings.apiKey),
+			option.WithBaseURL(settings.URL),
+			httpClientOpts,
+		)
+	}
+
+	defaultModels := &ModelSettings{
+		Default: ModelBase,
+		Mapping: map[Model]string{
+			ModelBase:  anthropic.ModelClaude3_5HaikuLatest,
+			ModelLarge: anthropic.ModelClaude3_5SonnetLatest,
+		},
+	}
+
+	return &anthropicProvider{
+		settings: settings,
+		models:   defaultModels,
+		client:   client,
+	}, nil
+}
+
+func (p *anthropicProvider) String() string {
+	return "Anthropic"
+}
+
+func (p *anthropicProvider) Models(ctx context.Context) (ModelResponse, error) {
+	return ModelResponse{
+		Data: []ModelInfo{
+			{ID: ModelBase},
+			{ID: ModelLarge},
+		},
+	}, nil
+}
+
+func convertToAnthropicMessages(messages []openai.ChatCompletionMessage) ([]anthropic.MessageParam, string) {
+	anthropicMessages := make([]anthropic.MessageParam, 0, len(messages))
+	var systemPrompt string
+
+	// Extract system message if present
+	if len(messages) > 0 && messages[0].Role == "system" {
+		systemPrompt = messages[0].Content
+	}
+
+	for _, msg := range messages {
+		switch msg.Role {
+		case "user":
+			anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(
+				anthropic.NewTextBlock(msg.Content),
+			))
+		case "assistant":
+			// Skip assistant messages as they'll be included in the response
+			continue
+		case "system":
+			// System messages are handled separately
+			continue
+		}
+	}
+
+	return anthropicMessages, systemPrompt
+}
+
+func convertToOpenAIResponse(resp *anthropic.Message, model string) openai.ChatCompletionResponse {
+	return openai.ChatCompletionResponse{
+		ID:      resp.ID,
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   model,
+		Choices: []openai.ChatCompletionChoice{
+			{
+				Index: 0,
+				Message: openai.ChatCompletionMessage{
+					Role:    "assistant",
+					Content: resp.Content[0].Text,
+				},
+				FinishReason: "stop",
+			},
+		},
+		Usage: openai.Usage{
+			PromptTokens:     int(resp.Usage.InputTokens),
+			CompletionTokens: int(resp.Usage.OutputTokens),
+			TotalTokens:      int(resp.Usage.InputTokens + resp.Usage.OutputTokens),
+		},
+	}
+}
+
+func (p *anthropicProvider) ChatCompletion(ctx context.Context, req ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+	messages, systemPrompt := convertToAnthropicMessages(req.Messages)
+	log.DefaultLogger.Info("model", "model", req.Model)
+	model := req.Model.toAnthropic(p.models)
+
+	// Anthropic requires a max tokens value
+	if req.MaxTokens == 0 {
+		req.MaxTokens = 1000
+	}
+
+	// Create Anthropic request
+	params := anthropic.MessageNewParams{
+		Model:     anthropic.F(model),
+		MaxTokens: anthropic.F(int64(req.MaxTokens)),
+		Messages:  anthropic.F(messages),
+	}
+
+	if systemPrompt != "" {
+		params.System = anthropic.F([]anthropic.TextBlockParam{
+			anthropic.NewTextBlock(systemPrompt),
+		})
+	}
+
+	// Make request
+	resp, err := p.client.Messages.New(ctx, params)
+	if err != nil {
+		log.DefaultLogger.Error("error creating anthropic chat completion", "err", err)
+		return openai.ChatCompletionResponse{}, err
+	}
+
+	return convertToOpenAIResponse(resp, model), nil
+}
+
+func (p *anthropicProvider) ChatCompletionStream(ctx context.Context, req ChatCompletionRequest) (<-chan ChatCompletionStreamResponse, error) {
+	messages, systemPrompt := convertToAnthropicMessages(req.Messages)
+
+	// Anthropic requires a max tokens value
+	if req.MaxTokens == 0 {
+		req.MaxTokens = 1000
+	}
+
+	params := anthropic.MessageNewParams{
+		Model:     anthropic.F(req.Model.toAnthropic(p.models)),
+		MaxTokens: anthropic.F(int64(req.MaxTokens)),
+		Messages:  anthropic.F(messages),
+	}
+
+	if systemPrompt != "" {
+		params.System = anthropic.F([]anthropic.TextBlockParam{
+			anthropic.NewTextBlock(systemPrompt),
+		})
+	}
+
+	stream := p.client.Messages.NewStreaming(ctx, params)
+	c := make(chan ChatCompletionStreamResponse)
+
+	go func() {
+		defer close(c)
+
+		message := anthropic.Message{}
+		for stream.Next() {
+			event := stream.Current()
+			if err := message.Accumulate(event); err != nil {
+				log.DefaultLogger.Error("error accumulating message", "err", err)
+				c <- ChatCompletionStreamResponse{Error: err}
+				return
+			}
+
+			switch delta := event.Delta.(type) {
+			case anthropic.ContentBlockDeltaEventDelta:
+				if delta.Text != "" {
+					c <- ChatCompletionStreamResponse{
+						ChatCompletionStreamResponse: openai.ChatCompletionStreamResponse{
+							ID:      message.ID,
+							Object:  "chat.completion.chunk",
+							Created: time.Now().Unix(),
+							Model:   string(req.Model),
+							Choices: []openai.ChatCompletionStreamChoice{
+								{
+									Index: 0,
+									Delta: openai.ChatCompletionStreamChoiceDelta{
+										Content: delta.Text,
+									},
+									FinishReason: openai.FinishReasonNull,
+								},
+							},
+						},
+					}
+				}
+			}
+		}
+
+		if err := stream.Err(); err != nil {
+			if err != io.EOF {
+				log.DefaultLogger.Error("anthropic stream error", "err", err)
+				c <- ChatCompletionStreamResponse{Error: err}
+			}
+		}
+	}()
+
+	return c, nil
+}
+
+func (p *anthropicProvider) ListAssistants(ctx context.Context, limit *int, order *string, after *string, before *string) (openai.AssistantsList, error) {
+	return openai.AssistantsList{}, fmt.Errorf("anthropic does not support assistants")
+}
+
+func (p *anthropicProvider) GetChatCompletionsPath() string {
+	return "anthropic/v1/chat/completions"
+}

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"strings"
 
+	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/sashabaranov/go-openai"
 )
 
@@ -57,6 +58,19 @@ func (m Model) toOpenAI(modelSettings *ModelSettings) string {
 			return "gpt-4o-mini"
 		case ModelLarge:
 			return "gpt-4o"
+		}
+		panic(fmt.Sprintf("unrecognized model: %s", m))
+	}
+	return modelSettings.getModel(m)
+}
+
+func (m Model) toAnthropic(modelSettings *ModelSettings) string {
+	if modelSettings == nil || len(modelSettings.Mapping) == 0 {
+		switch m {
+		case ModelBase:
+			return anthropic.ModelClaude3_5SonnetLatest
+		case ModelLarge:
+			return anthropic.ModelClaude3_5SonnetLatest
 		}
 		panic(fmt.Sprintf("unrecognized model: %s", m))
 	}

--- a/packages/grafana-llm-app/pkg/plugin/provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/provider.go
@@ -12,6 +12,8 @@ func createProvider(settings *Settings) (LLMProvider, error) {
 		return NewAzureProvider(settings.OpenAI, settings.Models.Default)
 	case ProviderTypeGrafana:
 		return NewGrafanaProvider(*settings)
+	case ProviderTypeAnthropic:
+		return NewAnthropicProvider(settings.Anthropic, settings.Models)
 	case ProviderTypeTest:
 		return &settings.OpenAI.TestProvider, nil
 	default:

--- a/packages/grafana-llm-app/provisioning/plugins/test-provider/grafana-llm-app.yaml
+++ b/packages/grafana-llm-app/provisioning/plugins/test-provider/grafana-llm-app.yaml
@@ -60,6 +60,7 @@ apps:
 
     secureJsonData:
       # openAIKey: $OPENAI_API_KEY
+      # anthropicKey: $ANTHROPIC_API_KEY
       # mock EncodedAccessToken "thestack:thetoken"
       # base64EncodedAccessToken: dGhlc3RhY2s6dGhldG9rZW4=
       # openAIKey: $AZURE_OPENAI_API_KEY

--- a/packages/grafana-llm-app/src/components/AppConfig/AnthropicConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AnthropicConfig.tsx
@@ -1,0 +1,68 @@
+import React, { ChangeEvent } from 'react';
+
+import { Field, FieldSet, Input, SecretInput, useStyles2 } from '@grafana/ui';
+
+import { testIds } from 'components/testIds';
+import { getStyles, Secrets, SecretsSet } from './AppConfig';
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com';
+
+export interface AnthropicSettings {
+  // The URL to reach Anthropic.
+  url?: string;
+  // If the LLM features have been explicitly disabled.
+  disabled?: boolean;
+}
+
+export function AnthropicConfig({
+  settings,
+  secrets,
+  secretsSet,
+  onChange,
+  onChangeSecrets,
+}: {
+  settings: AnthropicSettings;
+  onChange: (settings: AnthropicSettings) => void;
+  secrets: Secrets;
+  secretsSet: SecretsSet;
+  onChangeSecrets: (secrets: Secrets) => void;
+}) {
+  const s = useStyles2(getStyles);
+  // Helper to update settings using the name of the HTML event.
+  const onChangeField = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange({
+      ...settings,
+      [event.currentTarget.name]:
+        event.currentTarget.type === 'checkbox' ? event.currentTarget.checked : event.currentTarget.value.trim(),
+    });
+  };
+
+  return (
+    <FieldSet>
+      <Field label="API URL" className={s.marginTop}>
+        <Input
+          width={60}
+          name="url"
+          data-testid={testIds.appConfig.anthropicUrl}
+          value={ANTHROPIC_API_URL}
+          placeholder={ANTHROPIC_API_URL}
+          onChange={onChangeField}
+          disabled={true}
+        />
+      </Field>
+
+      <Field label="API Key">
+        <SecretInput
+          width={60}
+          data-testid={testIds.appConfig.anthropicKey}
+          name="anthropicKey"
+          value={secrets.anthropicKey}
+          isConfigured={secretsSet.anthropicKey ?? false}
+          placeholder="sk-ant-..."
+          onChange={(e) => onChangeSecrets({ ...secrets, anthropicKey: e.currentTarget.value })}
+          onReset={() => onChangeSecrets({ ...secrets, anthropicKey: '' })}
+        />
+      </Field>
+    </FieldSet>
+  );
+}

--- a/packages/grafana-llm-app/src/components/AppConfig/AnthropicLogo.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AnthropicLogo.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useTheme2 } from '@grafana/ui';
+
+export function AnthropicLogo({ width, height }: { width: number; height: number }) {
+  const theme = useTheme2();
+  
+  return (
+    <svg width={width} height={height} viewBox="0 0 92.2 65" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M66.5,0H52.4l25.7,65h14.1L66.5,0z M25.7,0L0,65h14.4l5.3-13.6h26.9L51.8,65h14.4L40.5,0C40.5,0,25.7,0,25.7,0z
+        M24.3,39.3l8.8-22.8l8.8,22.8H24.3z" fill={theme.colors.text.primary}/>
+    </svg>
+  );
+}

--- a/packages/grafana-llm-app/src/components/AppConfig/AppConfig.test.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AppConfig.test.tsx
@@ -39,6 +39,7 @@ describe('Components/AppConfig', () => {
     render(<AppConfig plugin={plugin} query={props.query} />);
 
     expect(screen.queryByRole('group', { name: /openai settings/i })).toBeInTheDocument();
+    expect(screen.queryByTestId(testIds.appConfig.provider)).toBeInTheDocument();
     // expect(screen.queryByTestId(testIds.appConfig.openAIKey)).toBeInTheDocument();
     // expect(screen.queryByTestId(testIds.appConfig.openAIOrganizationID)).toBeInTheDocument();
     // expect(screen.queryByTestId(testIds.appConfig.openAIUrl)).toBeInTheDocument();

--- a/packages/grafana-llm-app/src/components/AppConfig/AppConfig.test.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AppConfig.test.tsx
@@ -32,23 +32,26 @@ describe('Components/AppConfig', () => {
     } as unknown as AppConfigProps;
   });
 
-  test('renders the "API Settings" fieldset with API key, API url inputs and button', () => {
-    const plugin = { meta: { ...props.plugin.meta, enabled: false } };
+  test('renders OpenAI configuration when provider is OpenAI', () => {
+    const plugin = { meta: { ...props.plugin.meta, enabled: false, jsonData: { provider: 'openai' } } };
 
     // @ts-ignore - We don't need to provide `addConfigPage()` and `setChannelSupport()` for these tests
     render(<AppConfig plugin={plugin} query={props.query} />);
 
     expect(screen.queryByRole('group', { name: /openai settings/i })).toBeInTheDocument();
     expect(screen.queryByTestId(testIds.appConfig.provider)).toBeInTheDocument();
-    // expect(screen.queryByTestId(testIds.appConfig.openAIKey)).toBeInTheDocument();
-    // expect(screen.queryByTestId(testIds.appConfig.openAIOrganizationID)).toBeInTheDocument();
-    // expect(screen.queryByTestId(testIds.appConfig.openAIUrl)).toBeInTheDocument();
-    // expect(screen.queryByTestId(testIds.appConfig.model)).toBeInTheDocument();
-    expect(screen.queryByRole('group', { name: /vector settings/i })).toBeInTheDocument();
-    expect(screen.queryByTestId(testIds.appConfig.qdrantSecure)).toBeInTheDocument();
-    expect(screen.queryByTestId(testIds.appConfig.qdrantAddress)).toBeInTheDocument();
-    // Don't expect to see the Grafana vector API field when type is qdrant
-    expect(screen.queryByTestId(testIds.appConfig.grafanaVectorApiUrl)).toBeNull();
+    expect(screen.queryByRole('button', { name: /save & test/i })).toBeInTheDocument();
+  });
+
+  test('renders Anthropic configuration when provider is Anthropic', () => {
+    const plugin = { meta: { ...props.plugin.meta, enabled: false, jsonData: { provider: 'anthropic' } } };
+
+    // @ts-ignore - We don't need to provide `addConfigPage()` and `setChannelSupport()` for these tests
+    render(<AppConfig plugin={plugin} query={props.query} />);
+
+    expect(screen.queryByRole('group', { name: /openai settings/i })).toBeInTheDocument();
+    expect(screen.queryByTestId(testIds.appConfig.anthropicUrl)).toBeInTheDocument();
+    expect(screen.queryByTestId(testIds.appConfig.anthropicKey)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /save & test/i })).toBeInTheDocument();
   });
 });

--- a/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
@@ -11,15 +11,17 @@ import { ModelSettings } from './ModelConfig';
 import { ShowHealthCheckResult } from './HealthCheck';
 import { LLMConfig } from './LLMConfig';
 import { OpenAISettings } from './OpenAI';
+import { AnthropicSettings } from './AnthropicConfig';
 import { VectorConfig, VectorSettings } from './Vector';
 ///////////////////////
 
-export type ProviderType = 'openai' | 'azure' | 'grafana' | 'test' | 'custom';
+export type ProviderType = 'openai' | 'azure' | 'grafana' | 'test' | 'custom' | 'anthropic';
 
 export interface AppPluginSettings {
   provider?: ProviderType;
   disabled?: boolean;
   openAI?: OpenAISettings;
+  anthropic?: AnthropicSettings;
   vector?: VectorSettings;
   models?: ModelSettings;
   // The enableGrafanaManagedLLM flag will enable the plugin to use Grafana-managed OpenAI
@@ -30,6 +32,7 @@ export interface AppPluginSettings {
 
 export type Secrets = {
   openAIKey?: string;
+  anthropicKey?: string;
   qdrantApiKey?: string;
   vectorStoreBasicAuthPassword?: string;
   vectorEmbedderBasicAuthPassword?: string;
@@ -42,6 +45,7 @@ export type SecretsSet = {
 function initialSecrets(secureJsonFields: KeyValue<boolean>): SecretsSet {
   return {
     openAIKey: secureJsonFields.openAIKey ?? false,
+    anthropicKey: secureJsonFields.anthropicKey ?? false,
     vectorEmbedderBasicAuthPassword: secureJsonFields.vectorEmbedderBasicAuthPassword ?? false,
     vectorStoreBasicAuthPassword: secureJsonFields.vectorStoreBasicAuthPassword ?? false,
     qdrantApiKey: secureJsonFields.qdrantApiKey ?? false,

--- a/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
@@ -9,9 +9,11 @@ import { ModelConfig } from './ModelConfig';
 import { DevSandbox } from './DevSandbox';
 import { OpenAIConfig } from './OpenAI';
 import { OpenAILogo } from './OpenAILogo';
+import { AnthropicConfig } from './AnthropicConfig';
+import { AnthropicLogo } from './AnthropicLogo';
 
-// LLMOptions are the 3 possible UI options for LLMs (grafana-provided cloud-only).
-export type LLMOptions = 'grafana-provided' | 'openai' | 'test' | 'disabled' | 'unconfigured' | 'custom';
+// LLMOptions are the possible UI options for LLMs (grafana-provided cloud-only).
+export type LLMOptions = 'grafana-provided' | 'openai' | 'test' | 'disabled' | 'unconfigured' | 'custom' | 'anthropic';
 
 // This maps the current settings to decide what UI selection (LLMOptions) to show
 function getLLMOptionFromSettings(settings: AppPluginSettings): LLMOptions {
@@ -32,6 +34,8 @@ function getLLMOptionFromSettings(settings: AppPluginSettings): LLMOptions {
       return 'test';
     case 'grafana':
       return 'grafana-provided';
+    case 'anthropic':
+      return 'anthropic';
     default:
       return 'unconfigured';
   }
@@ -115,6 +119,12 @@ export function LLMConfig({
         onChange({ ...settings, provider: 'openai', disabled: false, openAI: { disabled: false } });
         setPreviousOpenAIProvider(undefined);
       }
+    }
+  };
+
+  const selectAnthropicProvider = () => {
+    if (llmOption !== 'anthropic') {
+      onChange({ ...settings, provider: 'anthropic', disabled: false });
     }
   };
 
@@ -242,7 +252,27 @@ export function LLMConfig({
               )}
             </Card.Description>
             <Card.Figure>
-              <OpenAILogo width={20} height={20} />
+              <OpenAILogo width={20} height={20}/>
+            </Card.Figure>
+          </Card>
+        </div>
+        <div onClick={selectAnthropicProvider}>
+          <Card isSelected={llmOption === 'anthropic'} className={s.cardWithoutBottomMargin}>
+            <Card.Heading>Use Anthropic API</Card.Heading>
+            <Card.Description>
+              Enable LLM features in Grafana using Anthropic&apos;s Claude models
+              {llmOption === 'anthropic' && (
+                <AnthropicConfig
+                  settings={settings.anthropic ?? {}}
+                  onChange={(anthropic) => onChange({ ...settings, anthropic })}
+                  secrets={secrets}
+                  secretsSet={secretsSet}
+                  onChangeSecrets={onChangeSecrets}
+                />
+              )}
+            </Card.Description>
+            <Card.Figure>
+              <AnthropicLogo width={20} height={20} />
             </Card.Figure>
           </Card>
         </div>
@@ -282,7 +312,7 @@ export function LLMConfig({
           </Card.Figure>
         </Card>
       </FieldSet>
-      {(llmOption === 'openai' || llmOption === 'custom') && (
+      {(llmOption === 'openai' || llmOption === 'custom' || llmOption === 'anthropic') && (
         <FieldSet label="Models" className={s.sidePadding}>
           <ModelConfig
             provider={settings.provider ?? 'openai'}

--- a/packages/grafana-llm-app/src/components/testIds.ts
+++ b/packages/grafana-llm-app/src/components/testIds.ts
@@ -5,6 +5,8 @@ export const testIds = {
     openAIKey: 'data-testid ac-openai-api-key',
     openAIOrganizationID: 'data-testid ac-openai-api-organization-id',
     openAIUrl: 'data-testid ac-openai-api-url',
+    anthropicKey: 'data-testid ac-anthropic-api-key',
+    anthropicUrl: 'data-testid ac-anthropic-api-url',
     vectorEnabled: 'data-testid ac-vector-enabled',
     qdrantAddress: 'data-testid ac-qdrant-address',
     qdrantSecure: 'data-testid ac-qdrant-secure',


### PR DESCRIPTION
This PR adds support for using Anthropic's Claude models as an LLM provider in the Grafana LLM app. Users can now choose between OpenAI, Anthropic, and other providers when configuring LLM features.

## Key changes

- Added new `ProviderTypeAnthropic` and associated settings structures
- Integrated Anthropic SDK and default model mappings
- Updated UI to include Anthropic as a provider option with dedicated configuration panel
- Updated provider factory to handle Anthropic provider type


Closes #504