### PR TITLE
chore: make plugin auto enabled

### DIFF
--- a/packages/grafana-llm-app/src/plugin.json
+++ b/packages/grafana-llm-app/src/plugin.json
@@ -3,6 +3,7 @@
   "type": "app",
   "name": "LLM",
   "id": "grafana-llm-app",
+  "autoEnabled": true,
   "backend": true,
   "streaming": true,
   "executable": "gpx_llm",


### PR DESCRIPTION
This PR makes the app plugin auto enabled.
This is required to make the plugins not allow users to disable plugins from the catalog as part of grafana/grafana-community-team#318
