### PR TITLE
update action versions in plugin-release

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -131,7 +131,7 @@ jobs:
           tag: v${{ steps.metadata.outputs.plugin-version }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: upload-dir
           path: __to-upload__
@@ -157,7 +157,7 @@ jobs:
           token: ${{ steps.get_installation_token.outputs.token }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: upload-dir
           path: ${{ needs.build-release.outputs.upload-folder }}


### PR DESCRIPTION
Releasing a new version of the plugin is failing due to old versions of some of our actions. This PR updates most of the actions, namely the artifact ones, to more recent versions.

See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ for more information