### PR TITLE
fix: update build:all command to also build plugin frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "npm run build --workspaces",
-    "build:all": "npm run frontend:build && npm run backend:build",
+    "build:all": "npm run build && npm run backend:build",
     "dev": "npm run frontend:build && npm run backend:build && npm run build -w @grafana/llm && concurrently --names 'llm-frontend,llm-app' 'npm run dev -w @grafana/llm' 'npm run dev -w @grafana/llm-app' -c 'bgBlue.bold,bgMagenta.bold'",
     "e2e:ci": "npm run e2e:ci --workspace=@grafana/llm-app",
     "backend:update-sdk": "npm run backend:update-sdk --workspace=@grafana/llm-app",


### PR DESCRIPTION
This must have been changed accidentally in a recent commit
because it worked before.
