### PR TITLE
Release v0.13.1 of the plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15898,7 +15898,7 @@
     },
     "packages/grafana-llm-app": {
       "name": "@grafana/llm-app",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.13.5",
@@ -15962,7 +15962,7 @@
     },
     "packages/grafana-llm-frontend": {
       "name": "@grafana/llm",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "react-use": "^17.6.0",

--- a/packages/grafana-llm-app/package.json
+++ b/packages/grafana-llm-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/llm-app",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Plugin to easily allow llm based extensions to grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/packages/grafana-llm-frontend/README.md
+++ b/packages/grafana-llm-frontend/README.md
@@ -7,7 +7,7 @@ First, add the latest version of `@grafana/llm` to your dependencies in package.
 ```json
 {
   "dependencies": {
-    "@grafana/llm": "0.13.0"
+    "@grafana/llm": "0.13.1"
   }
 }
 ```

--- a/packages/grafana-llm-frontend/package.json
+++ b/packages/grafana-llm-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/llm",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A grafana library for llm",
   "exports": {
     ".": {


### PR DESCRIPTION
v0.13.0 had build issues; this should resolve them all. The build workflow
wants to push a tag but we shouldn't remove the existing tag, so a new version
bump will have to do.
