### PR TITLE
Bug: duplicate healthcheck details for backwards compatiblity

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/health.go
+++ b/packages/grafana-llm-app/pkg/plugin/health.go
@@ -34,8 +34,10 @@ type vectorHealthDetails struct {
 
 type healthCheckDetails struct {
 	LLMProvider llmProviderHealthDetails `json:"llmProvider"`
-	Vector      vectorHealthDetails      `json:"vector"`
-	Version     string                   `json:"version"`
+	// clone of LLMProvider health details for backwards compatibility (< 0.13.0)
+	OpenAI  llmProviderHealthDetails `json:"openAI"`
+	Vector  vectorHealthDetails      `json:"vector"`
+	Version string                   `json:"version"`
 }
 
 func getVersion() string {
@@ -203,6 +205,7 @@ func (a *App) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) 
 
 	details := healthCheckDetails{
 		LLMProvider: provider,
+		OpenAI:      provider,
 		Vector:      vector,
 		Version:     getVersion(),
 	}

--- a/packages/grafana-llm-app/pkg/plugin/health_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/health_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana-llm-app/pkg/plugin/vector"
 	"github.com/grafana/grafana-llm-app/pkg/plugin/vector/store"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
 )
 
 type mockVectorService struct{}
@@ -277,6 +278,12 @@ func TestCheckHealth(t *testing.T) {
 			if err = json.Unmarshal(resp.JSONDetails, &details); err != nil {
 				t.Errorf("non-JSON response details (%s): %s", resp.JSONDetails, err)
 			}
+
+			// Make sure that OpenAI is populated for backwards compatability.
+			// We can consider removing this in the future after we are
+			// confident frontends have upgraded.
+			assert.Equal(t, details.LLMProvider, details.OpenAI)
+
 			if details.LLMProvider.OK != tc.expDetails.LLMProvider.OK ||
 				details.LLMProvider.Assistant.OK != tc.expDetails.LLMProvider.Assistant.OK ||
 				details.LLMProvider.Assistant.Error != tc.expDetails.LLMProvider.Assistant.Error ||


### PR DESCRIPTION
<0.13.0 grafana/llm frontend package check explicitly for openAI in the healthcheck.

Releasing plugin backend > 0.13.0 would cause all LLM powered features to stop working if they did not also have grafana/llm version > 0.13.0. Since changes in Grafana rolls out slowly this would require us to pin the plugin versions for certain Grafana versions and it would break things for OSS/enterprise.

This PR simply duplicates the llmProvider healthcheck details under openAI

**Consideration for reviewers:**

Alternatively, we could revert the healthcheck field llmProvider -> openAI, change frontend to check for llmProvider or openAI, and then roll rename later. Since the healthcheck detail/endpoint isn't very public, it might not be quite that bad.