### PR TITLE
Release v0.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15898,7 +15898,7 @@
     },
     "packages/grafana-llm-app": {
       "name": "@grafana/llm-app",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.13.5",
@@ -15962,7 +15962,7 @@
     },
     "packages/grafana-llm-frontend": {
       "name": "@grafana/llm",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "Apache-2.0",
       "dependencies": {
         "react-use": "^17.6.0",

--- a/packages/grafana-llm-app/package.json
+++ b/packages/grafana-llm-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/llm-app",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Plugin to easily allow llm based extensions to grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/packages/grafana-llm-frontend/README.md
+++ b/packages/grafana-llm-frontend/README.md
@@ -7,7 +7,7 @@ First, add the latest version of `@grafana/llm` to your dependencies in package.
 ```json
 {
   "dependencies": {
-    "@grafana/llm": "0.13.1"
+    "@grafana/llm": "0.13.2"
   }
 }
 ```

--- a/packages/grafana-llm-frontend/package.json
+++ b/packages/grafana-llm-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/llm",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "A grafana library for llm",
   "exports": {
     ".": {


### PR DESCRIPTION
Makes the health check backwards compatible to support mismatched frontend versions. The backend still needs to be running v0.13 for v0.13 versions of the frontend to work, i.e. this will still not be forwards compatible.