### PR TITLE
Allow enabling of dev sandbox via jsonData

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/settings.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings.go
@@ -170,6 +170,9 @@ type Settings struct {
 
 	// LLMGateway provides Grafana-managed OpenAI.
 	LLMGateway LLMGatewaySettings `json:"llmGateway"`
+
+	// Allows enabling the dev sandbox on the plugin page.
+	EnableDevSandbox bool `json:"enableDevSandbox"`
 }
 
 func loadSettings(appSettings backend.AppInstanceSettings) (*Settings, error) {

--- a/packages/grafana-llm-app/provisioning/plugins/grafana-vector-api/grafana-llm-app.yaml
+++ b/packages/grafana-llm-app/provisioning/plugins/grafana-vector-api/grafana-llm-app.yaml
@@ -4,6 +4,7 @@ apps:
   - type: grafana-llm-app
     jsonData:
       base64EncodedAccessTokenSet: True
+      enableDevSandbox: true
       # enableGrafanaManagedLLM: True
       # displayVectorStoreOptions: False
       provider: openai

--- a/packages/grafana-llm-app/provisioning/plugins/openai-qdrant/grafana-llm-app.yaml
+++ b/packages/grafana-llm-app/provisioning/plugins/openai-qdrant/grafana-llm-app.yaml
@@ -3,6 +3,7 @@ apiVersion: 1
 apps:
   - type: grafana-llm-app
     jsonData:
+      enableDevSandbox: true
       provider: openai
       openAI:
         url: https://api.openai.com

--- a/packages/grafana-llm-app/provisioning/plugins/test-provider/grafana-llm-app.yaml
+++ b/packages/grafana-llm-app/provisioning/plugins/test-provider/grafana-llm-app.yaml
@@ -4,6 +4,7 @@ apps:
   - type: grafana-llm-app
     jsonData:
       base64EncodedAccessTokenSet: True
+      enableDevSandbox: true
       # enableGrafanaManagedLLM: True
       # displayVectorStoreOptions: False
       provider: test

--- a/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AppConfig.tsx
@@ -28,6 +28,7 @@ export interface AppPluginSettings {
   // This will only work for Grafana Cloud install plugins
   enableGrafanaManagedLLM?: boolean;
   displayVectorStoreOptions?: boolean;
+  enableDevSandbox?: boolean;
 }
 
 export type Secrets = {

--- a/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
@@ -136,7 +136,7 @@ export function LLMConfig({
 
   return (
     <>
-      {process.env.NODE_ENV === 'development' && <DevSandbox />}
+      {settings.enableDevSandbox && <DevSandbox />}
       <FieldSet label="OpenAI Settings" className={s.sidePadding}>
         {allowGrafanaManagedLLM && (
           <div onClick={selectGrafanaManaged}>


### PR DESCRIPTION
The dev sandbox can be helpful in deployed instances to verify if the LLM is working, and soon to see which MCP tools are available. Allow turning it on in dev or other deployed instances via jsonData rather than requiring a development build.