### PR TITLE
chore: bump github.com/grafana/mcp-grafana to 0.2.2

### DIFF
--- a/packages/grafana-llm-app/go.mod
+++ b/packages/grafana-llm-app/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20250108132429-8d7e1f158f65
 	github.com/grafana/grafana-plugin-sdk-go v0.274.0
 	github.com/grafana/incident-go v0.0.0-20250211094540-dc6a98fdae43
-	github.com/grafana/mcp-grafana v0.2.1
+	github.com/grafana/mcp-grafana v0.2.2
 	github.com/mark3labs/mcp-go v0.13.0
 	github.com/qdrant/go-client v1.13.0
 	github.com/sashabaranov/go-openai v1.38.0

--- a/packages/grafana-llm-app/go.sum
+++ b/packages/grafana-llm-app/go.sum
@@ -102,6 +102,8 @@ github.com/grafana/incident-go v0.0.0-20250211094540-dc6a98fdae43 h1:+MCsOKi5BJ1
 github.com/grafana/incident-go v0.0.0-20250211094540-dc6a98fdae43/go.mod h1:3QDfdZOWKRxNhMJFL+0C/+12+jLNHDlt0VKNr/i9Daw=
 github.com/grafana/mcp-grafana v0.2.1 h1:krX36YhPG9XllDmX7uRinJlYLICVEBFlKkG//qRq8Bo=
 github.com/grafana/mcp-grafana v0.2.1/go.mod h1:nTHG2vNZdNbs637Tau8PafcuYhtzs6WBqiBDrPlDdBI=
+github.com/grafana/mcp-grafana v0.2.2 h1:YCBs+fy5KrX0KwsjP2oy3y/wN+wYhaM+5g7PsMM+4W4=
+github.com/grafana/mcp-grafana v0.2.2/go.mod h1:nTHG2vNZdNbs637Tau8PafcuYhtzs6WBqiBDrPlDdBI=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=

--- a/packages/grafana-llm-app/pkg/plugin/app.go
+++ b/packages/grafana-llm-app/pkg/plugin/app.go
@@ -131,6 +131,7 @@ func newMCPServer() *mcp.GrafanaLiveServer {
 	tools.AddSearchTools(srv)
 	tools.AddIncidentTools(srv)
 	tools.AddPrometheusTools(srv)
+	tools.AddLokiTools(srv)
 	s := mcp.NewGrafanaLiveServer(srv, mcp.WithGrafanaLiveContextFunc(mcp.ContextFunc))
 	return s
 }


### PR DESCRIPTION
Includes the new Loki tools.
