### PR TITLE
Switch to Anthropic's OpenAI-compatible API

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/anthropic_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/anthropic_provider.go
@@ -3,38 +3,34 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
-	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/sashabaranov/go-openai"
 )
 
+// anthropicProvider implements the LLMProvider interface using Anthropic's OpenAI-compatible API.
+// See: https://docs.anthropic.com/en/api/openai-sdk
 type anthropicProvider struct {
 	settings AnthropicSettings
 	models   *ModelSettings
-	client   *anthropic.Client
+	client   *openai.Client
 }
 
 func NewAnthropicProvider(settings AnthropicSettings, models *ModelSettings) (LLMProvider, error) {
-	httpClientOpts := option.WithHTTPClient(&http.Client{
+	client := &http.Client{
 		Timeout: 2 * time.Minute,
-	})
-	client := anthropic.NewClient(
-		option.WithAPIKey(settings.apiKey),
-		httpClientOpts,
-	)
-
-	if settings.URL != "" {
-		client = anthropic.NewClient(
-			option.WithAPIKey(settings.apiKey),
-			option.WithBaseURL(settings.URL),
-			httpClientOpts,
-		)
 	}
+	config := openai.DefaultConfig(settings.apiKey)
+	base, err := url.JoinPath(settings.URL, "/v1")
+	if err != nil {
+		return nil, fmt.Errorf("join url: %w", err)
+	}
+	config.BaseURL = base
+	config.HTTPClient = client
 
 	defaultModels := &ModelSettings{
 		Default: ModelBase,
@@ -47,7 +43,7 @@ func NewAnthropicProvider(settings AnthropicSettings, models *ModelSettings) (LL
 	return &anthropicProvider{
 		settings: settings,
 		models:   defaultModels,
-		client:   client,
+		client:   openai.NewClientWithConfig(config),
 	}, nil
 }
 
@@ -60,158 +56,36 @@ func (p *anthropicProvider) Models(ctx context.Context) (ModelResponse, error) {
 	}, nil
 }
 
-func convertToAnthropicMessages(messages []openai.ChatCompletionMessage) ([]anthropic.MessageParam, string) {
-	anthropicMessages := make([]anthropic.MessageParam, 0, len(messages))
-	var systemPrompt string
-
-	// Extract system message if present
-	if len(messages) > 0 && messages[0].Role == "system" {
-		systemPrompt = messages[0].Content
-	}
-
-	for _, msg := range messages {
-		switch msg.Role {
-		case "user":
-			anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(
-				anthropic.NewTextBlock(msg.Content),
-			))
-		case "assistant":
-			// Skip assistant messages as they'll be included in the response
-			continue
-		case "system":
-			// System messages are handled separately
-			continue
-		}
-	}
-
-	return anthropicMessages, systemPrompt
-}
-
-func convertToOpenAIResponse(resp *anthropic.Message, model string) openai.ChatCompletionResponse {
-	return openai.ChatCompletionResponse{
-		ID:      resp.ID,
-		Object:  "chat.completion",
-		Created: time.Now().Unix(),
-		Model:   model,
-		Choices: []openai.ChatCompletionChoice{
-			{
-				Index: 0,
-				Message: openai.ChatCompletionMessage{
-					Role:    "assistant",
-					Content: resp.Content[0].Text,
-				},
-				FinishReason: "stop",
-			},
-		},
-		Usage: openai.Usage{
-			PromptTokens:     int(resp.Usage.InputTokens),
-			CompletionTokens: int(resp.Usage.OutputTokens),
-			TotalTokens:      int(resp.Usage.InputTokens + resp.Usage.OutputTokens),
-		},
-	}
-}
-
 func (p *anthropicProvider) ChatCompletion(ctx context.Context, req ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
-	messages, systemPrompt := convertToAnthropicMessages(req.Messages)
-	log.DefaultLogger.Info("model", "model", req.Model)
-	model := req.Model.toAnthropic(p.models)
+	r := req.ChatCompletionRequest
+	r.Model = req.Model.toAnthropic(p.models)
+	log.DefaultLogger.Info("model", "model", r.Model)
 
 	// Anthropic requires a max tokens value
-	if req.MaxTokens == 0 {
-		req.MaxTokens = 1000
+	if r.MaxTokens == 0 {
+		r.MaxTokens = 1000
 	}
 
-	// Create Anthropic request
-	params := anthropic.MessageNewParams{
-		Model:     anthropic.F(model),
-		MaxTokens: anthropic.F(int64(req.MaxTokens)),
-		Messages:  anthropic.F(messages),
-	}
-
-	if systemPrompt != "" {
-		params.System = anthropic.F([]anthropic.TextBlockParam{
-			anthropic.NewTextBlock(systemPrompt),
-		})
-	}
-
-	// Make request
-	resp, err := p.client.Messages.New(ctx, params)
+	resp, err := p.client.CreateChatCompletion(ctx, r)
 	if err != nil {
 		log.DefaultLogger.Error("error creating anthropic chat completion", "err", err)
 		return openai.ChatCompletionResponse{}, err
 	}
 
-	return convertToOpenAIResponse(resp, model), nil
+	return resp, nil
 }
 
 func (p *anthropicProvider) ChatCompletionStream(ctx context.Context, req ChatCompletionRequest) (<-chan ChatCompletionStreamResponse, error) {
-	messages, systemPrompt := convertToAnthropicMessages(req.Messages)
+	r := req.ChatCompletionRequest
+	r.Model = req.Model.toAnthropic(p.models)
+	log.DefaultLogger.Info("model", "model", r.Model)
 
 	// Anthropic requires a max tokens value
-	if req.MaxTokens == 0 {
-		req.MaxTokens = 1000
+	if r.MaxTokens == 0 {
+		r.MaxTokens = 1000
 	}
 
-	params := anthropic.MessageNewParams{
-		Model:     anthropic.F(req.Model.toAnthropic(p.models)),
-		MaxTokens: anthropic.F(int64(req.MaxTokens)),
-		Messages:  anthropic.F(messages),
-	}
-
-	if systemPrompt != "" {
-		params.System = anthropic.F([]anthropic.TextBlockParam{
-			anthropic.NewTextBlock(systemPrompt),
-		})
-	}
-
-	stream := p.client.Messages.NewStreaming(ctx, params)
-	c := make(chan ChatCompletionStreamResponse)
-
-	go func() {
-		defer close(c)
-
-		message := anthropic.Message{}
-		for stream.Next() {
-			event := stream.Current()
-			if err := message.Accumulate(event); err != nil {
-				log.DefaultLogger.Error("error accumulating message", "err", err)
-				c <- ChatCompletionStreamResponse{Error: err}
-				return
-			}
-
-			switch delta := event.Delta.(type) {
-			case anthropic.ContentBlockDeltaEventDelta:
-				if delta.Text != "" {
-					c <- ChatCompletionStreamResponse{
-						ChatCompletionStreamResponse: openai.ChatCompletionStreamResponse{
-							ID:      message.ID,
-							Object:  "chat.completion.chunk",
-							Created: time.Now().Unix(),
-							Model:   string(req.Model),
-							Choices: []openai.ChatCompletionStreamChoice{
-								{
-									Index: 0,
-									Delta: openai.ChatCompletionStreamChoiceDelta{
-										Content: delta.Text,
-									},
-									FinishReason: openai.FinishReasonNull,
-								},
-							},
-						},
-					}
-				}
-			}
-		}
-
-		if err := stream.Err(); err != nil {
-			if err != io.EOF {
-				log.DefaultLogger.Error("anthropic stream error", "err", err)
-				c <- ChatCompletionStreamResponse{Error: err}
-			}
-		}
-	}()
-
-	return c, nil
+	return streamOpenAIRequest(ctx, r, p.client)
 }
 
 func (p *anthropicProvider) ListAssistants(ctx context.Context, limit *int, order *string, after *string, before *string) (openai.AssistantsList, error) {

--- a/packages/grafana-llm-app/pkg/plugin/anthropic_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/anthropic_provider.go
@@ -59,7 +59,7 @@ func (p *anthropicProvider) Models(ctx context.Context) (ModelResponse, error) {
 func (p *anthropicProvider) ChatCompletion(ctx context.Context, req ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
 	r := req.ChatCompletionRequest
 	r.Model = req.Model.toAnthropic(p.models)
-	log.DefaultLogger.Info("model", "model", r.Model)
+	log.DefaultLogger.Debug("model", "model", r.Model)
 
 	// Anthropic requires a max tokens value
 	if r.MaxTokens == 0 {
@@ -78,7 +78,7 @@ func (p *anthropicProvider) ChatCompletion(ctx context.Context, req ChatCompleti
 func (p *anthropicProvider) ChatCompletionStream(ctx context.Context, req ChatCompletionRequest) (<-chan ChatCompletionStreamResponse, error) {
 	r := req.ChatCompletionRequest
 	r.Model = req.Model.toAnthropic(p.models)
-	log.DefaultLogger.Info("model", "model", r.Model)
+	log.DefaultLogger.Debug("model", "model", r.Model)
 
 	// Anthropic requires a max tokens value
 	if r.MaxTokens == 0 {


### PR DESCRIPTION
This PR updates the Anthropic provider to use Anthropic's OpenAI-compatible API instead of their native SDK. 


### Key changes
- Refactored `anthropic_provider.go` to use the OpenAI client removing format conversion logic
- Better helpers and streaming handling for `llm.ts`
- Improvements in the `DevSandbox.tsx` for better DevEx

This change reduces code complexity and maintenance burden while providing the same functionality through a unified API approach.

Resolves https://github.com/grafana/grafana-llm-app/issues/600.
This pull request should be merged, and PR #602 should be closed in favor of this one.

Partially helps with #614