### PR TITLE
Update release instructions for NPM package

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ It is recommended to run these using npm commands from root so that the entire p
 - Bump version in `packages/grafana-llm-app/package.json` (e.g., 0.2.0 to 0.2.1)
 - Add notes to changelog describing changes since last release
 - Merge PR for a branch containing those changes into main
-- Trigger release from "actions" tab on Github.
+- Trigger "Plugin Release" from the Actions tab on Github.
+
+### NPM Release
+This is for the npm package `@grafana/llm`.
+- Bump version in `packages/grafana-llm-frontend/package.json` (e.g., 0.2.0 to 0.2.1)
+- Trigger "NPM Release" action from the Actions tab on Github.
 
 ### llmclient Release
-- Push a new tag to the repo (e.g., `git tag -a 0.X.X -m "llmclient v0.X.X release"`)
+- Push a new tag to the repo (e.g., `git tag -a llmclient/v0.X.X -m "llmclient v0.X.X release"`)

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ It is recommended to run these using npm commands from root so that the entire p
 - Trigger release from "actions" tab on Github.
 
 ### llmclient Release
-- Push a new tag to the repo (e.g., `git tag -a llmclient/v0.X.X -m "llmclient v0.X.X release"`)
+- Push a new tag to the repo (e.g., `git tag -a v0.X.X -m "llmclient v0.X.X release"`)

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ It is recommended to run these using npm commands from root so that the entire p
 - Trigger release from "actions" tab on Github.
 
 ### llmclient Release
-- Push a new tag to the repo (e.g., `git tag -a v0.X.X -m "llmclient v0.X.X release"`)
+- Push a new tag to the repo (e.g., `git tag -a 0.X.X -m "llmclient v0.X.X release"`)


### PR DESCRIPTION
~Noticed we are not using the old notation anymore, updating instructions to just use `XX.XX.XX`~

`llmclient` release instructions were correct, adding an additional note for NPM release. 