### PR TITLE
Update default OpenAI models to GPT 4.1

### DIFF
--- a/packages/grafana-llm-app/CHANGELOG.md
+++ b/packages/grafana-llm-app/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Update model defaults:
+  - Base: `gpt-4o-mini` to `gpt-4.1-mini`
+  - Large: `gpt-4o` to `gpt-4.1`
+
 ## 0.16.0
 
 - chore: bump github.com/grafana/mcp-grafana to 0.2.4 by @sd2k in #618. This adds more tools to retrieve dashboards and OnCall details.

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider.go
@@ -55,9 +55,9 @@ func (m Model) toOpenAI(modelSettings *ModelSettings) string {
 	if modelSettings == nil || len(modelSettings.Mapping) == 0 {
 		switch m {
 		case ModelBase:
-			return "gpt-4o-mini"
+			return "gpt-4.1-mini"
 		case ModelLarge:
-			return "gpt-4o"
+			return "gpt-4.1"
 		}
 		panic(fmt.Sprintf("unrecognized model: %s", m))
 	}

--- a/packages/grafana-llm-app/pkg/plugin/settings.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings.go
@@ -121,8 +121,8 @@ func (c ModelSettings) getModel(model Model) string {
 var DEFAULT_MODEL_SETTINGS = &ModelSettings{
 	Default: ModelBase,
 	Mapping: map[Model]string{
-		ModelBase:  "gpt-4o-mini",
-		ModelLarge: "gpt-4o",
+		ModelBase:  "gpt-4.1-mini",
+		ModelLarge: "gpt-4.1",
 	},
 }
 


### PR DESCRIPTION
We are seeing significant improvements when using GPT 4.1 compared to 4o in our internal benchmarks.