### PR TITLE
Update OpenAI model defaults to 4.1 in frontend

### DIFF
--- a/packages/grafana-llm-app/src/components/AppConfig/ModelConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/ModelConfig.tsx
@@ -22,13 +22,13 @@ const DEFAULT_MODEL_ID = openai.Model.BASE;
 const MODEL_MAPPING_CONFIG: ModelMappingConfig[] = [
   {
     id: openai.Model.BASE,
-    name: 'gpt-4o-mini',
+    name: 'gpt-4.1-mini',
     label: 'Base',
     description: 'A fast and cost-effective model for efficient, high-throughput tasks.',
   },
   {
     id: openai.Model.LARGE,
-    name: 'gpt-4o',
+    name: 'gpt-4.1',
     label: 'Large',
     description: 'A larger, higher cost model for more advanced tasks with longer context windows.',
   },


### PR DESCRIPTION
As was pointed out in https://github.com/grafana/grafana-llm-app/pull/632#issuecomment-2813391757, may as well have new users configure OpenAI use the better models.