### PR TITLE
chore: use go-version-file to setup Go in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: packages/grafana-llm-app/go.mod
+          cache-dependency-path: packages/grafana-llm-app/go.sum
       - name: Install Mage
         uses: magefile/mage-action@v3
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version-file: packages/grafana-llm-app/go.mod
       - name: Install Mage
         uses: magefile/mage-action@v3
         with:


### PR DESCRIPTION
Otherwise the Go version can become out of date with the
version we actually need (as has happened now).
