### PR TITLE
fix: allow OpenAI path to be customised

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/openai_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/openai_provider.go
@@ -24,7 +24,14 @@ func NewOpenAIProvider(settings OpenAISettings, models *ModelSettings) (LLMProvi
 		Timeout: 2 * time.Minute,
 	}
 	cfg := openai.DefaultConfig(settings.apiKey)
-	base, err := url.JoinPath(settings.URL, "/v1")
+
+	// Defensively check that APIPath is not nil to avoid potential panics
+	// if settings aren't loaded using loadSettings.
+	if settings.APIPath == nil {
+		*settings.APIPath = defaultOpenAIAPIPath
+	}
+
+	base, err := url.JoinPath(settings.URL, *settings.APIPath)
 	if err != nil {
 		return nil, fmt.Errorf("join url: %w", err)
 	}

--- a/packages/grafana-llm-app/pkg/plugin/settings.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings.go
@@ -12,8 +12,15 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
-const openAIKey = "openAIKey"
-const encodedTenantAndTokenKey = "base64EncodedAccessToken"
+const (
+	openAIKey                = "openAIKey"
+	encodedTenantAndTokenKey = "base64EncodedAccessToken"
+)
+
+var (
+	// This has to be a var so we can take its address later.
+	defaultOpenAIAPIPath = "/v1"
+)
 
 type ProviderType string
 
@@ -30,6 +37,10 @@ const (
 type OpenAISettings struct {
 	// The URL to the OpenAI provider
 	URL string `json:"url"`
+
+	// The API path to append to the URL.
+	// If nil, the default path of /v1 is used.
+	APIPath *string `json:"apiPath"`
 
 	// The OrgID to be passed to OpenAI in requests
 	OrganizationID string `json:"organizationId"`
@@ -205,6 +216,10 @@ func loadSettings(appSettings backend.AppInstanceSettings) (*Settings, error) {
 	// an empty string.
 	if settings.OpenAI.URL == "" {
 		settings.OpenAI.URL = "https://api.openai.com"
+	}
+	// Use default API path if not overridden in settings.
+	if settings.OpenAI.APIPath == nil {
+		settings.OpenAI.APIPath = &defaultOpenAIAPIPath
 	}
 	if settings.Anthropic.URL == "" {
 		settings.Anthropic.URL = "https://api.anthropic.com"

--- a/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/LLMConfig.tsx
@@ -248,6 +248,7 @@ export function LLMConfig({
                   secrets={secrets}
                   secretsSet={secretsSet}
                   onChangeSecrets={onChangeSecrets}
+                  allowCustomPath={false}
                 />
               )}
             </Card.Description>
@@ -288,6 +289,7 @@ export function LLMConfig({
                   secrets={secrets}
                   secretsSet={secretsSet}
                   onChangeSecrets={onChangeSecrets}
+                  allowCustomPath={true}
                 />
               )}
             </Card.Description>

--- a/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
@@ -1,7 +1,7 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useEffect, useState } from 'react';
 
 import { openai } from '@grafana/llm';
-import { Field, FieldSet, Input, SecretInput, Select, useStyles2 } from '@grafana/ui';
+import { Checkbox, Field, FieldSet, Input, SecretInput, Select, Stack, useStyles2 } from '@grafana/ui';
 
 import { SelectableValue } from '@grafana/data';
 import { testIds } from 'components/testIds';
@@ -14,6 +14,9 @@ const AZURE_OPENAI_URL_TEMPLATE = 'https://<resource-name>.openai.azure.com';
 export interface OpenAISettings {
   // The URL to reach OpenAI.
   url?: string;
+  // The API path to append to the URL.
+  // Defaults to /v1 if not provided.
+  apiPath?: string;
   // The organization ID for OpenAI.
   organizationId?: string;
   // Whether to use Azure OpenAI.
@@ -30,12 +33,14 @@ export function OpenAIConfig({
   secretsSet,
   onChange,
   onChangeSecrets,
+  allowCustomPath = false,
 }: {
   settings: OpenAISettings;
   onChange: (settings: OpenAISettings) => void;
   secrets: Secrets;
   secretsSet: SecretsSet;
   onChangeSecrets: (secrets: Secrets) => void;
+  allowCustomPath: boolean;
 }) {
   const s = useStyles2(getStyles);
   // Helper to update settings using the name of the HTML event.
@@ -55,6 +60,23 @@ export function OpenAIConfig({
       url: value === 'openai' ? OPENAI_API_URL : '',
     });
   };
+
+  // Use separate state to track whether the user has checked the useCustomPath checkbox.
+  // This is required because we don't store the checkbox state as a bool in the settings,
+  // which our onChangeField assumes we do.
+  const [useCustomPath, setUseCustomPath] = useState(settings.apiPath !== undefined);
+  useEffect(() => {
+    // When the user checks the useCustomPath checkbox we want to immediately
+    // update the apiPath field, since the empty string is a valid value;
+    // the user shouldn't have to manually modify the input field to trigger
+    // the onChange.
+    // Similarly when they uncheck the checkbox, we want to clear the apiPath field.
+    const apiPath = useCustomPath ? (settings.apiPath ?? '') : undefined;
+    onChange({
+      ...settings,
+      apiPath,
+    });
+  }, [useCustomPath]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <FieldSet>
@@ -96,9 +118,34 @@ export function OpenAIConfig({
         />
       </Field>
 
-      <Field
-        label={settings.provider === 'azure' ? 'Azure OpenAI Key' : 'API Key'}
-      >
+      {allowCustomPath && (
+        <Field
+          label="API Path"
+          description="Customize the API path appended to the URL. Defaults to /v1 if unchecked."
+          className={s.marginTop}
+        >
+          <Stack direction="row" gap={1} alignItems={'center'}>
+            <Checkbox
+              data-testid={testIds.appConfig.customizeOpenAIApiPath}
+              name="Use custom API path"
+              value={useCustomPath}
+              onChange={(e) => setUseCustomPath(e.currentTarget.checked)}
+            />
+
+            <Input
+              width={57}
+              name="apiPath"
+              data-testid={testIds.appConfig.openAIApiPath}
+              value={settings.apiPath ?? ''}
+              placeholder={useCustomPath ? '' : '/v1'}
+              onChange={onChangeField}
+              disabled={!useCustomPath}
+            />
+          </Stack>
+        </Field>
+      )}
+
+      <Field label={settings.provider === 'azure' ? 'Azure OpenAI Key' : 'API Key'}>
         <SecretInput
           width={60}
           data-testid={testIds.appConfig.openAIKey}

--- a/packages/grafana-llm-app/src/components/testIds.ts
+++ b/packages/grafana-llm-app/src/components/testIds.ts
@@ -3,6 +3,8 @@ export const testIds = {
     container: 'data-testid ac-container',
     provider: 'data-testid ac-provider',
     openAIKey: 'data-testid ac-openai-api-key',
+    customizeOpenAIApiPath: 'data-testid ac-customize-openai-api-path',
+    openAIApiPath: 'data-testid ac-openai-api-path',
     openAIOrganizationID: 'data-testid ac-openai-api-organization-id',
     openAIUrl: 'data-testid ac-openai-api-url',
     anthropicKey: 'data-testid ac-anthropic-api-key',


### PR DESCRIPTION
Our OpenAI settings currently unconditionally append '/v1' to the
configured OpenAI URL, which isn't correct for many OpenAI-like
APIs. This commit allows the path to be customised. It defaults to
'/v1' if not overridden, so should be backwards compatible.

Expected behaviour in the UI:

- the custom API path field is only shown when the 'custom' provider
  is selected
- the custom API path field is disabled by default
- when the checkbox is checked, the custom API path field is enabled
  and set to ''
- when the checkbox is unchecked, the custom API path field is disabled
  again and the apiPath field is set to `undefined`.

Fixes #642.