### PR TITLE
chore: use vault secrets instead of GitHub secrets

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -67,9 +67,16 @@ jobs:
       - name: Run backend tests
         run: npm run backend:test
 
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b
+        with:
+          repo_secrets: |
+            NPM_TOKEN=npm:token
+          export_env: false
+
       - name: Publish to NPM
         run: |
           cd packages/grafana-llm-frontend
           npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GRAFANABOT_NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).NPM_TOKEN }}

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -182,12 +182,6 @@ jobs:
             app_id=grafana-machine-learning-github-app:app-id
             app_installation_id=grafana-machine-learning-github-app:app-installation-id
             private_key=grafana-machine-learning-github-app:private-key
-          export_env: false
-
-      - id: get-access-policy-secret
-        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b
-        with:
-          repo_secrets: |
             GRAFANA_CLOUD_ACCESS_POLICY_TOKEN=grafana-cloud-access-policy:token
           export_env: false
 
@@ -246,5 +240,5 @@ jobs:
           plugin-version: ${{ needs.build-release.outputs.version-tag }}
           plugin-dist: "https://www.github.com/grafana/grafana-llm-app/tree/main/packages/grafana-llm-app/dist"
           gcp-bucket: integration-artifacts
-          gcom-token: ${{ fromJSON(steps.get-access-policy-secret.outputs.secrets).GRAFANA_CLOUD_ACCESS_POLICY_TOKEN }}
+          gcom-token: ${{ fromJSON(steps.get-secrets.outputs.secrets).GRAFANA_CLOUD_ACCESS_POLICY_TOKEN }}
           gcom-api: ${{ env.GCOM_ROOT }}

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -38,6 +38,12 @@ jobs:
             private_key=grafana-machine-learning-github-app:private-key
           export_env: false
 
+      - id: get-access-policy-secret
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b
+        with:
+          repo_secrets: |
+            GRAFANA_API_KEY=grafana-cloud-access-policy:token
+
       - name: Print secrets obfuscated summary to verify length and format
         run: |
           echo "Private Key Length: $(echo -n "${{ fromJSON(steps.get-secrets.outputs.secrets).private_key }}" | wc -c)"
@@ -165,7 +171,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: ['build-release']
     env:
-      GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_SIGNING_KEY }}
       GCOM_ROOT: https://grafana.com
     steps:
       - id: get-secrets
@@ -178,6 +183,13 @@ jobs:
             app_id=grafana-machine-learning-github-app:app-id
             app_installation_id=grafana-machine-learning-github-app:app-installation-id
             private_key=grafana-machine-learning-github-app:private-key
+          export_env: false
+
+      - id: get-access-policy-secret
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b
+        with:
+          repo_secrets: |
+            GRAFANA_CLOUD_ACCESS_POLICY_TOKEN=grafana-cloud-access-policy:token
           export_env: false
 
       - uses: tibdex/github-app-token@32691ba7c9e7063bd457bd8f2a5703138591fa58
@@ -235,5 +247,5 @@ jobs:
           plugin-version: ${{ needs.build-release.outputs.version-tag }}
           plugin-dist: "https://www.github.com/grafana/grafana-llm-app/tree/main/packages/grafana-llm-app/dist"
           gcp-bucket: integration-artifacts
-          gcom-token: ${{ env.GRAFANA_API_KEY }}
+          gcom-token: ${{ fromJSON(steps.get-access-policy-secret.outputs.secrets).GRAFANA_CLOUD_ACCESS_POLICY_TOKEN }}
           gcom-api: ${{ env.GCOM_ROOT }}

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -21,7 +21,6 @@ jobs:
       id-token: write
     env:
       plugin-dist-folder: ./packages/grafana-llm-app/dist
-      GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_SIGNING_KEY }} # Requires a Grafana API key from Grafana.com.
 
     outputs:
       upload-folder: ${{ steps.metadata.outputs.upload-folder }}


### PR DESCRIPTION
GitHub secrets will be removed soon; we should fetch secrets from Vault instead.

I've added the relevant repo secrets to Vault but had to regenerate a cloud access policy token for this plugin. Hard to say if it will all work smoothly until we do a release, unfortunately.
