### PR TITLE
Increase OBO user auth token TTL to 30 min

### DIFF
--- a/packages/grafana-llm-app/pkg/mcp/live_server.go
+++ b/packages/grafana-llm-app/pkg/mcp/live_server.go
@@ -162,6 +162,7 @@ func (s *GrafanaLiveServer) HandleStream(ctx context.Context, req *backend.RunSt
 		tokenExchangeResponse, err = s.tokenExchangeClient.Exchange(ctx, authn.TokenExchangeRequest{
 			Namespace: fmt.Sprintf("stack-%s", s.tenant),
 			Audiences: []string{"grafana"},
+			ExpiresIn: &[]int{1800}[0], // 30 minutes
 		})
 		if err != nil {
 			return fmt.Errorf("failed to perform token exchange with auth api: %w", err)


### PR DESCRIPTION
The on-behalf-of user auth tokens sometimes time out in the middle of a debugging session, increasing token TTLs which should to 30 min which should improve things for now.