### PR TITLE
feat: refresh Grafana access token before expiry in Cloud

### DIFF
--- a/packages/grafana-llm-app/pkg/mcp/live_server.go
+++ b/packages/grafana-llm-app/pkg/mcp/live_server.go
@@ -150,13 +150,14 @@ type liveSession struct {
 }
 
 // tokenTimeoutSeconds is the expiration time for the Grafana Live session token.
-var tokenTimeoutSeconds = int((time.Minute * 30).Seconds())
+var tokenTimeout = time.Minute * 30
 
 // tokenRefreshInterval is the time between token refreshes.
-var tokenRefreshInterval = time.Duration(tokenTimeoutSeconds) - time.Minute
+var tokenRefreshInterval = tokenTimeout - time.Minute
 
 // exchangeToken uses the token exchange API to create an access token for the Grafana Live session.
 func (s *GrafanaLiveServer) exchangeToken(ctx context.Context) (*authn.TokenExchangeResponse, error) {
+	tokenTimeoutSeconds := int(tokenTimeout.Seconds())
 	tr, err := s.tokenExchangeClient.Exchange(ctx, authn.TokenExchangeRequest{
 		Namespace: fmt.Sprintf("stack-%s", s.tenant),
 		Audiences: []string{"grafana"},
@@ -180,7 +181,7 @@ func (s *GrafanaLiveServer) HandleStream(ctx context.Context, req *backend.RunSt
 	// the channel being nil).
 	// Outside of Grafana Cloud it will just tick occasionally and be a no-op.
 	// The timer will fire one minute before the token is due to expire.
-	t := time.NewTimer(time.Duration(tokenTimeoutSeconds) - time.Minute)
+	t := time.NewTimer(tokenRefreshInterval)
 	defer t.Stop()
 	// Only do the token exchange if we are in Grafana Cloud.
 	if s.enableGrafanaManagedLLM {
@@ -219,7 +220,7 @@ func (s *GrafanaLiveServer) HandleStream(ctx context.Context, req *backend.RunSt
 			}
 			ls.accessToken = tr.Token
 			// Reset the timer so that it fires again one minute before the token is due to be expire.
-			t.Reset(time.Duration(tokenTimeoutSeconds) - time.Minute)
+			t.Reset(tokenRefreshInterval)
 		case <-s.done:
 			return nil
 		}


### PR DESCRIPTION
Prior to this commit, the Grafana Live session handler would not refresh
the access token before it expired. This causes issues when using long
running streams in Grafana, as the token would expire halfway through
the stream and the client would experience strange errors.

This commit adds a timer to the Grafana Live session handler to refresh
the access token one minute before it expires. On refresh, the timer
will reset to fire one minute before the token is due to expire again.
