### PR TITLE
feat: export 'enabled' function from mcp module of npm package

### DIFF
--- a/packages/grafana-llm-frontend/src/mcp.tsx
+++ b/packages/grafana-llm-frontend/src/mcp.tsx
@@ -181,7 +181,12 @@ type ClientResource = {
   read: () => ClientResult;
 };
 
-async function isEnabled(): Promise<boolean> {
+/**
+ * Check if the Grafana LLM app is installed and the MCP server is enabled for the current Grafana instance.
+ *
+ * @returns Whether MCP is enabled for the current Grafana instance.
+ */
+export async function enabled(): Promise<boolean> {
   try {
     const settings = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/settings`, undefined, undefined, {
       showSuccessAlert: false,
@@ -215,10 +220,10 @@ function createClientResource(appName: string, appVersion: string): ClientResour
     }
 
     try {
-      const enabled = await isEnabled();
-      if (!enabled) {
+      const isEnabled = await enabled();
+      if (!isEnabled) {
         status = 'success';
-        result = { client: null, enabled };
+        result = { client: null, enabled: isEnabled };
         clientMap.set(key, result);
         return result;
       }
@@ -228,7 +233,7 @@ function createClientResource(appName: string, appVersion: string): ClientResour
       });
       const transport = new GrafanaLiveTransport();
       await client.connect(transport);
-      result = { client, enabled };
+      result = { client, enabled: isEnabled };
       clientMap.set(key, result);
       status = 'success';
       return result;

--- a/packages/grafana-llm-frontend/src/mcp.tsx
+++ b/packages/grafana-llm-frontend/src/mcp.tsx
@@ -195,7 +195,13 @@ export async function enabled(): Promise<boolean> {
     if (!settings.enabled) {
       return false;
     }
-    return settings.jsonData.mcp.enabled;
+    // If the `enabled` property is present, it's an older version of the plugin;
+    // use this field.
+    if (settings.jsonData.mcp.enabled !== undefined) {
+      return settings.jsonData.mcp.enabled;
+    }
+    // Otherwise use the `disabled` property.
+    return !settings.jsonData.mcp.disabled;
   } catch (e) {
     logDebug(String(e));
     logDebug(


### PR DESCRIPTION
This will be useful for anyone using the MCP server outside of a
React component context.
