### PR TITLE
refactor: don't manually refresh tokens, use exchange client every time

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/app.go
+++ b/packages/grafana-llm-app/pkg/plugin/app.go
@@ -142,10 +142,15 @@ func newMCPServer(settings *Settings) (*mcp.GrafanaLiveServer, error) {
 	tools.AddOnCallTools(srv)
 	tools.AddAssertsTools(srv)
 	tools.AddSiftTools(srv)
-	return mcp.NewGrafanaLiveServer(srv,
-		mcp.WithGrafanaLiveContextFunc(mcp.ContextFunc),
+
+	m, err := mcp.NewGrafanaLiveServer(srv,
 		mcp.WithGrafanaTenant(settings.Tenant),
 		mcp.WithGrafanaManagedLLM(settings.EnableGrafanaManagedLLM),
 		mcp.WithLLMAppAccessPolicyToken(settings.GrafanaComAPIKey),
 	)
+	if err != nil {
+		return nil, err
+	}
+	m.SetContextFunc(m.ComposedContextFunc())
+	return m, err
 }


### PR DESCRIPTION
Rather than storing an access and ID token in the Grafana Live session,
re-obtain them every time by either going through the token exchange
client (for the access token) or using the one provided in the request
by Grafana (for the ID token).

To make it clear that we don't have one we can use, remove the access token
from the GrafanaLiveContextFunc signature, so that it's clearer that it
isn't automatically provided and should be refreshed each time.

Note that the token exchange client provided by the authn package already
handles caching and automatic refreshing of tokens, so we don't need to
deal with refreshing them ourselves.

This should have no functional impact, but will make it easier to add
token refreshing to other places (such as #691).
