### PR TITLE
refactor: add MCP struct and simplify access token usage

### DIFF
--- a/packages/grafana-llm-app/pkg/mcp/accesstoken.go
+++ b/packages/grafana-llm-app/pkg/mcp/accesstoken.go
@@ -1,0 +1,65 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/grafana/authlib/authn"
+)
+
+// tokenTimeout is the expiration time for the Grafana Live session token.
+// Note: We tried setting this to 30 minutes, but it caused the following error:
+// "failed to perform token exchange with auth api: invalid exchange response: invalid expiresIn: requested token expiration 30m0s exceeds maximum allowed expiration: 10m0s"
+const tokenTimeout = time.Minute * 10
+
+// accessTokenClient handles token exchange operations for Grafana Cloud authentication.
+// It manages the exchange of access policy tokens for temporary access tokens that can
+// be used to authenticate with Grafana services on behalf of users.
+// It will only exchange tokens if the access policy token is not empty and if we're
+// running in Grafana Cloud.
+type accessTokenClient struct {
+	// tokenExchangeClient is the client used to perform token exchanges with the auth API.
+	tokenExchangeClient *authn.TokenExchangeClient
+	// tenant is the Grafana Cloud tenant identifier.
+	tenant string
+	// isGrafanaCloud indicates whether this client is running in Grafana Cloud environment.
+	isGrafanaCloud bool
+}
+
+// newAccessTokenClient creates a new access token client for handling token exchange operations.
+// If accessPolicyToken is empty, the client will be created but token exchange will not be available.
+// Returns an error if the token exchange client cannot be initialized.
+func newAccessTokenClient(accessPolicyToken, tenant string, isGrafanaCloud bool) (*accessTokenClient, error) {
+	acc := &accessTokenClient{isGrafanaCloud: isGrafanaCloud, tenant: tenant}
+	if accessPolicyToken == "" {
+		return acc, nil
+	}
+	var err error
+	if acc.tokenExchangeClient, err = authn.NewTokenExchangeClient(authn.TokenExchangeConfig{
+		Token:            accessPolicyToken,
+		TokenExchangeURL: "http://api-lb.auth.svc.cluster.local./v1/sign-access-token", // TODO: make this configurable.
+	}); err != nil {
+		return nil, fmt.Errorf("create token exchange client: %w", err)
+	}
+	return acc, nil
+}
+
+// getAccessToken exchanges the access policy token for a temporary access token
+// that can be used to authenticate with Grafana services. Returns an empty string
+// if not running in Grafana Cloud or if no token exchange client is configured.
+func (a *accessTokenClient) getAccessToken(ctx context.Context) (string, error) {
+	if !a.isGrafanaCloud {
+		return "", nil
+	}
+	tokenTimeoutSeconds := int(tokenTimeout.Seconds())
+	t, err := a.tokenExchangeClient.Exchange(ctx, authn.TokenExchangeRequest{
+		Namespace: fmt.Sprintf("stack-%s", a.tenant),
+		Audiences: []string{"grafana"},
+		ExpiresIn: &tokenTimeoutSeconds,
+	})
+	if err != nil {
+		return "", fmt.Errorf("perform token exchange with auth api: %w", err)
+	}
+	return t.Token, nil
+}

--- a/packages/grafana-llm-app/pkg/mcp/mcp.go
+++ b/packages/grafana-llm-app/pkg/mcp/mcp.go
@@ -1,0 +1,78 @@
+package mcp
+
+import (
+	"fmt"
+
+	"github.com/grafana/mcp-grafana/tools"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// Settings contains configuration required by the MCP servers.
+type Settings struct {
+	// AccessToken is a Grafana Cloud access policy token that is exchanged with
+	// one that can be used to authenticate with Grafana, if we're using on-behalf-of
+	// auth.
+	AccessToken string
+
+	// ServiceAccountToken is the token provided by Grafana to the plugin,
+	// and is used to authenticate with Grafana if we're not using on-behalf-of
+	// auth.
+	ServiceAccountToken string
+
+	// Tenant is the Grafana Cloud tenant ID.
+	Tenant string
+
+	// IsGrafanaCloud indicates whether this is running in Grafana Cloud environment.
+	IsGrafanaCloud bool
+}
+
+// MCP represents the complete MCP (Model Context Protocol) infrastructure for Grafana.
+// It manages both the core MCP server and the Grafana Live server for handling
+// real-time communication with MCP clients.
+type MCP struct {
+	// Server is the core MCP server that handles tool registration and execution.
+	Server *server.MCPServer
+	// LiveServer handles Grafana Live connections for MCP communication.
+	LiveServer *GrafanaLiveServer
+	// Settings contains the configuration for the MCP servers.
+	Settings Settings
+
+	// accessTokenClient is the client for exchanging access policy tokens.
+	// This is stored here because it may be shared by different Transports in the future.
+	accessTokenClient *accessTokenClient
+}
+
+// New creates a new MCP instance with the provided settings and plugin version.
+// It initializes the MCP server with all Grafana tools and sets up the Live server
+// for handling real-time MCP communication.
+func New(settings Settings, pluginVersion string) (*MCP, error) {
+	srv := server.NewMCPServer("grafana-llm-app", pluginVersion)
+	tools.AddSearchTools(srv)
+	tools.AddDatasourceTools(srv)
+	tools.AddIncidentTools(srv)
+	tools.AddPrometheusTools(srv)
+	tools.AddLokiTools(srv)
+	tools.AddAlertingTools(srv)
+	tools.AddDashboardTools(srv)
+	tools.AddOnCallTools(srv)
+	tools.AddAssertsTools(srv)
+	tools.AddSiftTools(srv)
+
+	acc, err := newAccessTokenClient(settings.AccessToken, settings.Tenant, settings.IsGrafanaCloud)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create access token client: %w", err)
+	}
+
+	liveServer := NewGrafanaLiveServer(srv, acc, WithIsGrafanaCloud(settings.IsGrafanaCloud))
+	return &MCP{
+		Server:            srv,
+		LiveServer:        liveServer,
+		Settings:          settings,
+		accessTokenClient: acc,
+	}, nil
+}
+
+// Close shuts down the MCP instance, closing the Live server and cleaning up resources.
+func (m *MCP) Close() {
+	m.LiveServer.Close()
+}

--- a/packages/grafana-llm-app/pkg/plugin/stream.go
+++ b/packages/grafana-llm-app/pkg/plugin/stream.go
@@ -86,7 +86,7 @@ func (a *App) runChatCompletionsStream(ctx context.Context, req *backend.RunStre
 }
 
 func (a *App) runMCPStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return a.mcpServer.HandleStream(ctx, req, sender)
+	return a.mcpServer.LiveServer.HandleStream(ctx, req, sender)
 }
 
 func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
@@ -118,7 +118,7 @@ func (a *App) PublishStream(ctx context.Context, req *backend.PublishStreamReque
 	log.DefaultLogger.Debug(fmt.Sprintf("PublishStream: %s", req.Path), "data", string(req.Data))
 	// Handle messages for the MCP server.
 	if a.allowMCPRequest(req.Path) {
-		err := a.mcpServer.HandleMessage(ctx, req)
+		err := a.mcpServer.LiveServer.HandleMessage(ctx, req)
 		if errors.Is(err, mcp.ErrStreamNotFound) {
 			return &backend.PublishStreamResponse{
 				Status: backend.PublishStreamStatusNotFound,


### PR DESCRIPTION
This commit adds a new MCP struct that encapsulates the MCP server and Grafana Live server, as well as holding all MCP-related settings. Finally, it adds a new access token client that encapsulates the access token exchange process, including skipping it if we are not in Grafana Cloud.

Rather than manually refreshing access tokens, this relies on the fact that the authlib library's TokenExchangeClient will automatically cache and refresh the access token if it is expired.

Note: the restructuring of the MCP side is partly motivated by wanting to also use the access token client in the HTTP server in #691.

It might look like a net code addition but I think a lot of that is comments - it should be simpler to understand how!