### PR TITLE
fix: handle case when nested provider differs

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/azure_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/azure_provider.go
@@ -27,6 +27,7 @@ func NewAzureProvider(settings OpenAISettings, defaultModel Model) (LLMProvider,
 
 	// go-openai expects the URL without the '/openai' suffix, which is
 	// the same as us.
+	log.DefaultLogger.Debug("Using Azure OpenAI", "url", settings.URL)
 	cfg := openai.DefaultAzureConfig(settings.apiKey, settings.URL)
 	cfg.HTTPClient = client
 	// We pass the deployment as the name of the model, so just return the untransformed string.

--- a/packages/grafana-llm-app/pkg/plugin/provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/provider.go
@@ -7,6 +7,11 @@ func createProvider(settings *Settings) (LLMProvider, error) {
 
 	switch provider {
 	case ProviderTypeOpenAI, ProviderTypeCustom:
+		// Handle the case when the OpenAI provider is set to Azure
+		// for backwards compatibility.
+		if settings.OpenAI.Provider == ProviderTypeAzure {
+			return NewAzureProvider(settings.OpenAI, settings.Models.Default)
+		}
 		return NewOpenAIProvider(settings.OpenAI, settings.Models)
 	case ProviderTypeAzure:
 		return NewAzureProvider(settings.OpenAI, settings.Models.Default)


### PR DESCRIPTION
Some customers are reporting that their Azure OpenAI settings don't
seem to work, with the health check returning 404. It looks like this
is happening because while the nested 'provider' field is set to 'azure',
the root one is set to 'openai', so our backend doesn't create the correct
type of client.

This should fix https://github.com/grafana/support-escalations/issues/16670#issuecomment-2949047284.
