### PR TITLE
ci: use shared GitHub actions provided by plugins platform

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@custom-working-directory # zizmor: ignore[unpinned-uses]
     with:
       go-version: "1.24.1"
+      golangci-lint-version: "2.1.6"
       node-version: "22"
       working-directory: packages/grafana-llm-app
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Plugins - CD
+run-name: Deploy ${{ inputs.branch }} to ${{ inputs.environment }} by @${{ github.actor }}
+
+defaults:
+  run:
+    working-directory: packages/grafana-llm-app
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to publish from. Can be used to deploy PRs to dev
+        default: main
+      environment:
+        description: Environment to publish to
+        required: true
+        type: choice
+        options:
+          - "dev"
+          - "ops"
+          - "prod"
+      docs-only:
+        description: Only publish docs, do not publish the plugin
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  cd:
+    name: CD
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@bdb7870609eebc6d4795493affc2aa35bcbec829
+    with:
+      branch: ${{ github.event.inputs.branch }}
+      environment: ${{ github.event.inputs.environment }}
+      docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
+      # Disable playwright tests for now
+      run-playwright: false
+
+      # Choose the correct scope for the plugin version published to the catalog:
+      # - 'universal' (default) if the plugin in the catalog should be visible to all users
+      # - 'grafana_cloud' if the plugin in the catalog should be visible only to Grafana Cloud users (hidden for on-prem users)
+      scopes: universal
+      # scopes: grafana_cloud
+
+      grafana-cloud-deployment-type: provisioned
+      argo-workflow-slack-channel: "#machine-learning-deploys"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       go-version: "1.24.1"
       golangci-lint-version: "2.1.6"
       node-version: "22"
-      working-directory: packages/grafana-llm-app
+      plugin-directory: packages/grafana-llm-app
 
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,13 +20,16 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   cd:
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@custom-working-directory # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     with:
       go-version: "1.24.1"
       golangci-lint-version: "2.1.6"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ permissions: {}
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@custom-working-directory # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main # zizmor: ignore[unpinned-uses]
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,6 @@
 name: Plugins - CD
 run-name: Deploy ${{ inputs.branch }} to ${{ inputs.environment }} by @${{ github.actor }}
 
-defaults:
-  run:
-    working-directory: packages/grafana-llm-app
-
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,10 +30,11 @@ permissions:
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@bdb7870609eebc6d4795493affc2aa35bcbec829
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@custom-working-directory # zizmor: ignore[unpinned-uses]
     with:
       go-version: "1.24.1"
       node-version: "22"
+      working-directory: packages/grafana-llm-app
 
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,9 @@ jobs:
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@bdb7870609eebc6d4795493affc2aa35bcbec829
     with:
+      go-version: "1.24.1"
+      node-version: "22"
+
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,11 +33,16 @@ jobs:
       node-version: "22"
       plugin-directory: packages/grafana-llm-app
 
+      # Disable playwright tests for now
+      run-playwright: false
+      # The playwright action assumes that the plugin is in the root of the repository
+      # and gets the Grafana dependency from src/plugin.json. This is not the case for
+      # this plugin, so we need to explicitly set the Grafana dependency version.
+      run-playwright-with-grafana-dependency: ">=9.5.2"
+
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
-      # Disable playwright tests for now
-      run-playwright: false
 
       # Choose the correct scope for the plugin version published to the catalog:
       # - 'universal' (default) if the plugin in the catalog should be visible to all users

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,6 +22,7 @@ jobs:
       attestations: write
     with:
       go-version: "1.24.1"
+      golangci-lint-version: "2.1.6"
       node-version: "22"
       working-directory: packages/grafana-llm-app
       package-manager: npm

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,10 +8,6 @@ on:
 
 permissions: {}
 
-defaults:
-  run:
-    working-directory: packages/grafana-llm-app
-
 jobs:
   cd:
     name: CI / CD

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,6 +21,9 @@ jobs:
       id-token: write
       attestations: write
     with:
+      go-version: "1.24.1"
+      node-version: "22"
+
       # Checkout/build PR or main branch, depending on event
       branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   cd:
     name: CI / CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@custom-working-directory # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main # zizmor: ignore[unpinned-uses]
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,6 +23,13 @@ jobs:
       plugin-directory: packages/grafana-llm-app
       package-manager: npm
 
+      # Disable playwright tests for now.
+      run-playwright: false
+      # The playwright action assumes that the plugin is in the root of the repository
+      # and gets the Grafana dependency from src/plugin.json. This is not the case for
+      # this plugin, so we need to explicitly set the Grafana dependency version.
+      run-playwright-with-grafana-dependency: ">=9.5.2"
+
       # Checkout/build PR or main branch, depending on event
       branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
       go-version: "1.24.1"
       golangci-lint-version: "2.1.6"
       node-version: "22"
-      working-directory: packages/grafana-llm-app
+      plugin-directory: packages/grafana-llm-app
       package-manager: npm
 
       # Checkout/build PR or main branch, depending on event

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,39 @@
+name: Plugins - CI / CD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+defaults:
+  run:
+    working-directory: packages/grafana-llm-app
+
+jobs:
+  cd:
+    name: CI / CD
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    with:
+      # Checkout/build PR or main branch, depending on event
+      branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}
+
+      # When pushing to "main", publish and deploy to "dev" (CD). For PRs, skip publishing and deploying (run CI only)
+      environment: ${{ (github.event_name == 'push' && github.ref_name == 'main') && 'dev' || 'none' }}
+
+      # Deploy provisioned plugin to Grafana Cloud
+      grafana-cloud-deployment-type: provisioned
+      argo-workflow-slack-channel: "#machine-learning-deploys"
+
+      # Scope for the plugin published to the catalog. Setting this to "grafana_cloud" will make it visible only in Grafana Cloud
+      # (and hide it for on-prem). This is required for some provisioned plugins.
+      scopes: universal
+
+      # Add the git head ref sha to the plugin version as suffix (`+abcdef`). This is required for CD builds.
+      plugin-version-suffix: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ defaults:
 jobs:
   cd:
     name: CI / CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@custom-working-directory # zizmor: ignore[unpinned-uses]
     permissions:
       contents: write
       id-token: write
@@ -23,6 +23,7 @@ jobs:
     with:
       go-version: "1.24.1"
       node-version: "22"
+      working-directory: packages/grafana-llm-app
 
       # Checkout/build PR or main branch, depending on event
       branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,6 +24,7 @@ jobs:
       go-version: "1.24.1"
       node-version: "22"
       working-directory: packages/grafana-llm-app
+      package-manager: npm
 
       # Checkout/build PR or main branch, depending on event
       branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16700,6 +16700,7 @@
     "packages/grafana-llm-app": {
       "name": "@grafana/llm-app",
       "version": "0.21.2",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.13.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "server": "npm run server --workspace=@grafana/llm-app",
     "test": "concurrently --names 'llm-frontend,llm-app' 'npm run test:watch -w @grafana/llm' 'npm run test:watch -w @grafana/llm-app' -c 'bgBlue.bold,bgMagenta.bold'",
     "test:ci": "npm run test:ci --workspaces",
-    "typecheck": "npm run typecheck --workspaces"
+    "typecheck": "npm run build && npm run typecheck --workspaces"
   },
   "author": "Grafana",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "server": "npm run server --workspace=@grafana/llm-app",
     "test": "concurrently --names 'llm-frontend,llm-app' 'npm run test:watch -w @grafana/llm' 'npm run test:watch -w @grafana/llm-app' -c 'bgBlue.bold,bgMagenta.bold'",
     "test:ci": "npm run test:ci --workspaces",
-    "typecheck": "npm run build && npm run typecheck --workspaces"
+    "typecheck": "npm run typecheck --workspaces"
   },
   "author": "Grafana",
   "license": "Apache-2.0",

--- a/packages/grafana-llm-app/package.json
+++ b/packages/grafana-llm-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@grafana/llm-app",
   "version": "0.21.2",
+  "private": true,
   "description": "Plugin to easily allow llm based extensions to grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
@@ -18,6 +19,7 @@
     "e2e": "npm exec cypress install && npm exec grafana-e2e run",
     "e2e:ci": "npm run server:detach && npm exec cypress install && npm exec grafana-e2e run && npm run server:down",
     "e2e:update": "npm exec cypress install && npm exec grafana-e2e run --update-screenshots",
+    "preinstall": "cd ../.. && npm install --ignore-scripts && npm run build",
     "server": "docker compose up --build",
     "server:detach": "docker compose up --build -d",
     "server:down": "docker compose down",


### PR DESCRIPTION
This will get us automatic builds and pushes on every PR and commit to main, more comprehensive testing and linting, the ability to use the plugin catalog, and Argo Workflows for deployment.