### PR TITLE
ci: add GitHub action to bump version and generate changelog

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,140 @@
+name: Version bump and update changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver type of new version (major / minor / patch)"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      generate-changelog:
+        description: "Generate changelog"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get secrets from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
+        env:
+          VAULT_INSTANCE: ops
+        with:
+          vault_instance: ${{ env.VAULT_INSTANCE }}
+          common_secrets: |
+            GITHUB_APP_ID=plugins-platform-bot-app:app-id
+            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
+
+      - name: Generate GitHub token
+        id: generate-github-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ steps.generate-github-token.outputs.token }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Setup Git
+        shell: bash
+        run: |
+          git config user.name 'grafana-plugins-platform-bot[bot]'
+          git config user.email '144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com'
+
+      - name: Get previous tag before bumping
+        id: previous-tag
+        if: ${{ inputs.generate-changelog == 'true' }}
+        shell: bash
+        run: |
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "previous-tag=${PREVIOUS_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Bump version of plugin
+        id: bump-plugin
+        shell: bash
+        run: |
+          NEW_VERSION=$(npm version ${INPUT_VERSION} --no-git-tag-version)
+          echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+        working-directory: packages/grafana-llm-app
+
+      - name: Bump version of @grafana/llm package
+        id: bump-grafana-llm
+        shell: bash
+        run: |
+          NEW_VERSION=$(npm version ${INPUT_VERSION} --no-git-tag-version)
+          echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+        working-directory: packages/grafana-llm-frontend
+
+      # The lock file should be updated to contain the new versions, too.
+      - name: Regenerate lock file
+        shell: bash
+        run: |
+          npm install --package-lock-only
+
+      - name: Generate changelog
+        if: ${{ inputs.generate-changelog == 'true' }}
+        shell: bash
+        run: |
+          # Generate changelog
+          if [[ "${{ steps.previous-tag.outputs.previous-tag }}" == "v0.0.0" ]]; then
+            echo "No previous tag found ${{ steps.previous-tag.outputs.previous-tag }}, generating changelog for initial version only: v${{ steps.bump-plugin.outputs.new-version }}"
+            # For initial version, get all commits up to HEAD
+            npx generate-changelog -t HEAD
+          else
+            echo "Generating changelog from ${{ steps.previous-tag.outputs.previous-tag }} to HEAD"
+            npx generate-changelog -t ${{ steps.previous-tag.outputs.previous-tag }}...HEAD
+          fi
+
+          # Remove existing "Changelog" header anywhere in the file
+          sed -i '/^#\sChangelog$/Id' CHANGELOG.md
+          # Prepend the header to the top of the file
+          printf "# Changelog\n\n" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
+          # Format headers remove dates and unreleased
+          sed -i -E 's/^(#+ [0-9]+\.[0-9]+\.[0-9]+) \(([Uu]nreleased|[0-9]{4}-[0-9]{2}-[0-9]{2})\)/\1/' CHANGELOG.md
+
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+        # The CHANGELOG.md file is stored in the grafana-llm-app package because that's how plugins
+        # are set up.
+        working-directory: packages/grafana-llm-app
+
+      - name: Commit changes
+        shell: bash
+        run: |
+          git add grafana-llm-app/package.json grafana-llm-frontend/package.json package-lock.json
+          git add grafana-llm-app/CHANGELOG.md || true  # No-op if changelog not generated
+          git commit -m "chore(version): bump version to ${{ steps.bump-plugin.outputs.new-version }}"
+          git push origin main
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+
+      - name: Create git tag
+        shell: bash
+        run: |
+          git tag -a ${{ steps.bump-plugin.outputs.new-version }} -m "Release version ${{ steps.bump-plugin.outputs.new-version }}"
+
+      - name: Push tags
+        shell: bash
+        run: git push origin --tags


### PR DESCRIPTION
Note: a GitHub release will be created by the CD pipeline once we
publish to prod, not by this new action.

This was mostly copied from https://github.com/grafana/plugin-ci-workflows/blob/main/actions/plugins/version-bump-changelog/action.yml but adapted for our curious setup of having multiple packages which both need to be updated.