### PR TITLE
chore: relax @grafana/... dependencies in frontend package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16799,8 +16799,8 @@
         "uuid": "^11.0.5"
       },
       "devDependencies": {
-        "@grafana/data": "^10.4.0 ||^11",
-        "@grafana/runtime": "^10.4.0 || ^11",
+        "@grafana/data": "^10.4.0 || ^11 || ^12",
+        "@grafana/runtime": "^10.4.0 || ^11 || ^12",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@types/uuid": "^10.0.0",
         "prettier": "^3.4.2",
@@ -16813,8 +16813,8 @@
         "typescript": "5.6.2"
       },
       "peerDependencies": {
-        "@grafana/data": "^10.4.0 ||^11",
-        "@grafana/runtime": "^10.4.0 || ^11",
+        "@grafana/data": "^10.4.0 ||^11 || ^12",
+        "@grafana/runtime": "^10.4.0 || ^11 || ^12",
         "react": "^18",
         "rxjs": "^7.8.1"
       }

--- a/packages/grafana-llm-frontend/package.json
+++ b/packages/grafana-llm-frontend/package.json
@@ -40,8 +40,8 @@
   "author": "Grafana",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grafana/data": "^10.4.0 ||^11",
-    "@grafana/runtime": "^10.4.0 || ^11",
+    "@grafana/data": "^10.4.0 || ^11 || ^12",
+    "@grafana/runtime": "^10.4.0 || ^11 || ^12",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@types/uuid": "^10.0.0",
     "prettier": "^3.4.2",
@@ -60,8 +60,8 @@
     "uuid": "^11.0.5"
   },
   "peerDependencies": {
-    "@grafana/data": "^10.4.0 ||^11",
-    "@grafana/runtime": "^10.4.0 || ^11",
+    "@grafana/data": "^10.4.0 ||^11 || ^12",
+    "@grafana/runtime": "^10.4.0 || ^11 || ^12",
     "react": "^18",
     "rxjs": "^7.8.1"
   }


### PR DESCRIPTION
Grafana 12 has been out for a while now, we should support it just
fine, so relax the dependencies.

See https://github.com/grafana/grafana/issues/106749.
