### PR TITLE
fix: correctly pass user model settings to Anthropic provider

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/anthropic_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/anthropic_provider.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/sashabaranov/go-openai"
 )
@@ -32,17 +31,9 @@ func NewAnthropicProvider(settings AnthropicSettings, models *ModelSettings) (LL
 	config.BaseURL = base
 	config.HTTPClient = client
 
-	defaultModels := &ModelSettings{
-		Default: ModelBase,
-		Mapping: map[Model]string{
-			ModelBase:  string(anthropic.ModelClaude3_5HaikuLatest),
-			ModelLarge: string(anthropic.ModelClaude3_5SonnetLatest),
-		},
-	}
-
 	return &anthropicProvider{
 		settings: settings,
-		models:   defaultModels,
+		models:   models,
 		client:   openai.NewClientWithConfig(config),
 	}, nil
 }

--- a/packages/grafana-llm-app/playwright.config.ts
+++ b/packages/grafana-llm-app/playwright.config.ts
@@ -36,6 +36,14 @@ export default defineConfig<PluginOptions>({
     trace: 'on-first-retry',
   },
 
+  /* Configure screenshot comparison tolerance */
+  expect: {
+    // Allow up to 5% pixel difference for screenshots
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.05, // 5% tolerance (0.05 = 5%)
+    },
+  },
+
   /* Configure projects for major browsers */
   projects: [
     {


### PR DESCRIPTION
This variable was previously just being ignored, so model overrides had no
effect.

The default handling is done in Model.toAnthropic, which handles the
case where mapping is nil, so we don't need to do it here.
