### PR TITLE
fix: use npm 11 for version bump script

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -69,7 +69,7 @@ jobs:
         id: bump-plugin
         shell: bash
         run: |
-          NEW_VERSION=$(npm version ${INPUT_VERSION} --no-git-tag-version)
+          NEW_VERSION=$(npx npm@11 version ${INPUT_VERSION} --no-git-tag-version)
           echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
         env:
           INPUT_VERSION: ${{ inputs.version }}
@@ -80,7 +80,7 @@ jobs:
         id: bump-grafana-llm
         shell: bash
         run: |
-          NEW_VERSION=$(npm version ${INPUT_VERSION} --no-git-tag-version)
+          NEW_VERSION=$(npx npm@11 version ${INPUT_VERSION} --no-git-tag-version)
           echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
         env:
           INPUT_VERSION: ${{ inputs.version }}


### PR DESCRIPTION
Older versions don't output the version to stdout correctly,
they also include a bunch of other stuff (including newlines)
which causes the GITHUB_OUTPUT to be malformed.

Also reverts #735 since I don't think that was the underlying cause.