### PR TITLE
ci: use grep to only ever get correct version line

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -69,7 +69,7 @@ jobs:
         id: bump-plugin
         shell: bash
         run: |
-          NEW_VERSION=$(npx npm@11 version ${INPUT_VERSION} --no-git-tag-version)
+          NEW_VERSION=$(npm version ${INPUT_VERSION} --no-git-tag-version | grep -m 1 '^v')
           echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
         env:
           INPUT_VERSION: ${{ inputs.version }}
@@ -80,7 +80,7 @@ jobs:
         id: bump-grafana-llm
         shell: bash
         run: |
-          NEW_VERSION=$(npx npm@11 version ${INPUT_VERSION} --no-git-tag-version)
+          NEW_VERSION=$(npm version ${INPUT_VERSION} --no-git-tag-version | grep -m 1 '^v')
           echo "new-version=${NEW_VERSION}" >> $GITHUB_OUTPUT
         env:
           INPUT_VERSION: ${{ inputs.version }}


### PR DESCRIPTION
It turns out that being in a workspace causes npm version to output
weird stuff, not the npm version being old. This commit updates the
version bump command to grep for '^v' rather than using the full
output.
