### PR TITLE
feat(anthropic): Add placeholder and health check api key setting

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/health.go
+++ b/packages/grafana-llm-app/pkg/plugin/health.go
@@ -46,6 +46,25 @@ func getVersion() string {
 	return buildInfo.Version
 }
 
+// getUnconfiguredError returns a specific error message based on the provider type
+func (a *App) getUnconfiguredError() string {
+	provider := a.settings.getEffectiveProvider()
+
+	switch provider {
+	case ProviderTypeAnthropic:
+		return "Anthropic API key is not configured"
+	case ProviderTypeOpenAI:
+		return "OpenAI API key is not configured"
+	case ProviderTypeAzure:
+		if len(a.settings.OpenAI.AzureMapping) == 0 {
+			return "Azure model mappings are not configured"
+		}
+		return "Azure OpenAI API key is not configured"
+	default:
+		return "LLM provider not configured"
+	}
+}
+
 func (a *App) testProviderModel(ctx context.Context, model Model) error {
 	llmProvider, err := createProvider(a.settings)
 	if err != nil {
@@ -91,7 +110,7 @@ func (a *App) llmProviderHealth(ctx context.Context) (llmProviderHealthDetails, 
 	}
 
 	for _, model := range supportedModels {
-		health := modelHealth{OK: false, Error: "LLM provider not configured"}
+		health := modelHealth{OK: false, Error: a.getUnconfiguredError()}
 		if d.Configured {
 			health.OK = true
 			health.Error = ""

--- a/packages/grafana-llm-app/pkg/plugin/health.go
+++ b/packages/grafana-llm-app/pkg/plugin/health.go
@@ -56,10 +56,19 @@ func (a *App) getUnconfiguredError() string {
 	case ProviderTypeOpenAI:
 		return "OpenAI API key is not configured"
 	case ProviderTypeAzure:
-		if len(a.settings.OpenAI.AzureMapping) == 0 {
+		hasAPIKey := a.settings.OpenAI.apiKey != ""
+		hasMappings := len(a.settings.OpenAI.AzureMapping) > 0
+
+		if !hasAPIKey && !hasMappings {
+			return "Azure OpenAI API key and model mappings are not configured"
+		}
+		if !hasAPIKey {
+			return "Azure OpenAI API key is not configured"
+		}
+		if !hasMappings {
 			return "Azure model mappings are not configured"
 		}
-		return "Azure OpenAI API key is not configured"
+		return "Azure OpenAI configuration is incomplete"
 	default:
 		return "LLM provider not configured"
 	}

--- a/packages/grafana-llm-app/pkg/plugin/health_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/health_test.go
@@ -179,6 +179,31 @@ func TestCheckHealth(t *testing.T) {
 				Version: "unknown",
 			},
 		},
+		{
+			name: "anthropic unconfigured shows specific error",
+			settings: backend.AppInstanceSettings{
+				DecryptedSecureJSONData: map[string]string{},
+				JSONData: json.RawMessage(`{
+					"provider": "anthropic",
+					"anthropic": {
+						"url": "%s"
+					}
+				}`),
+			},
+			expDetails: healthCheckDetails{
+				LLMProvider: llmProviderHealthDetails{
+					Configured: false,
+					OK:         false,
+					Error:      "No functioning models are available",
+					Models: map[Model]modelHealth{
+						ModelBase:  {OK: false, Error: "Anthropic API key is not configured"},
+						ModelLarge: {OK: false, Error: "Anthropic API key is not configured"},
+					},
+				},
+				Vector:  vectorHealthDetails{},
+				Version: "unknown",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()

--- a/packages/grafana-llm-app/src/components/AppConfig/AnthropicConfig.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/AnthropicConfig.tsx
@@ -58,7 +58,7 @@ export function AnthropicConfig({
           name="anthropicKey"
           value={secrets.anthropicKey}
           isConfigured={secretsSet.anthropicKey ?? false}
-          placeholder="sk-ant-..."
+          placeholder={secretsSet.anthropicKey ? 'sk-ant-...' : 'not configured'}
           onChange={(e) => onChangeSecrets({ ...secrets, anthropicKey: e.currentTarget.value })}
           onReset={() => onChangeSecrets({ ...secrets, anthropicKey: '' })}
         />


### PR DESCRIPTION
Fixes: #749

ui:

<img width="892" height="451" alt="Screenshot 2025-07-18 at 5 12 28 PM" src="https://github.com/user-attachments/assets/967c0a7c-c81c-49d6-be7f-642eb46c25f6" />

health:

```
➜  grafana-llm-app git:(fix) ✗ curl -X GET "http://localhost:3000/api/plugins/grafana-llm-app/health" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   739  100   739    0     0   2106      0 --:--:-- --:--:-- --:--:--  2111
{
  "details": {
    "llmProvider": {
      "configured": false,
      "error": "No functioning models are available",
      "models": {
        "base": {
          "error": "Anthropic API key is not configured",
          "ok": false
        },
        "large": {
          "error": "Anthropic API key is not configured",
          "ok": false
        }
      },
      "ok": false
    },
    "openAI": {
      "configured": false,
      "error": "No functioning models are available",
      "models": {
        "base": {
          "error": "Anthropic API key is not configured",
          "ok": false
        },
        "large": {
          "error": "Anthropic API key is not configured",
          "ok": false
        }
      },
      "ok": false
    },
    "vector": {
      "enabled": true,
      "error": "vector service health check failed: vector store health: get health: Get \"http://vectorapi:8889/healthz\": dial tcp: lookup vectorapi on 127.0.0.11:53: no such host",
      "ok": false
    },
    "version": "0.22.3"
  },
  "message": "",
  "status": "OK"
}
```