### PR TITLE
chore: fix broken link in readme

### DIFF
--- a/packages/grafana-llm-app/src/README.md
+++ b/packages/grafana-llm-app/src/README.md
@@ -26,7 +26,7 @@ Grafana Cloud: the LLM app plugin is installed for everyone, but LLM features ar
 
 OSS or Enterprise: install and configure this plugin with your OpenAI-compatible API key to enable LLM-powered features across Grafana.
 
-For more detailed setup instructions see [LLM plugin](https://grafana.com/docs/grafana-cloud/alerting-and-irm/machine-learning/llm/llm-setup/) section under machine learning.
+For more detailed setup instructions see [LLM plugin](https://grafana.com/docs/grafana-cloud/machine-learning/llm/) section under machine learning.
 
 This includes new functionality inside Grafana itself, such as explaining panels, or in plugins,
 such as automated incident summaries, AI assistants for flame graphs and Sift error logs, and more.


### PR DESCRIPTION
Noticed on https://grafana.com/grafana/plugins/grafana-llm-app/?tab=overview that there was a broken link, believe this is where it should go