### PR TITLE
fix: use maxCompletionTokens instead of maxTokens

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/anthropic_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/anthropic_provider.go
@@ -57,8 +57,8 @@ func (p *anthropicProvider) ChatCompletion(ctx context.Context, req ChatCompleti
 	log.DefaultLogger.Debug("model", "model", r.Model)
 
 	// Anthropic requires a max tokens value
-	if r.MaxTokens == 0 {
-		r.MaxTokens = DefaultMaxCompletionTokens
+	if r.MaxCompletionTokens == 0 {
+		r.MaxCompletionTokens = DefaultMaxCompletionTokens
 	}
 
 	ForceUserMessage(&r)
@@ -78,8 +78,8 @@ func (p *anthropicProvider) ChatCompletionStream(ctx context.Context, req ChatCo
 	log.DefaultLogger.Debug("model", "model", r.Model)
 
 	// Anthropic requires a max tokens value
-	if r.MaxTokens == 0 {
-		r.MaxTokens = DefaultMaxCompletionTokens
+	if r.MaxCompletionTokens == 0 {
+		r.MaxCompletionTokens = DefaultMaxCompletionTokens
 	}
 
 	ForceUserMessage(&r)

--- a/packages/grafana-llm-app/pkg/plugin/health.go
+++ b/packages/grafana-llm-app/pkg/plugin/health.go
@@ -14,9 +14,9 @@ import (
 var supportedModels = []Model{ModelBase, ModelLarge}
 
 type modelHealth struct {
-	OK       bool `json:"ok"`
+	OK       bool   `json:"ok"`
 	Error    string `json:"error,omitempty"`
-	Response any `json:"response,omitempty"`
+	Response any    `json:"response,omitempty"`
 }
 
 type llmProviderHealthDetails struct {
@@ -66,7 +66,7 @@ func extractErrorResponse(err error) any {
 			}
 		}
 	}
-	
+
 	var apiErr *openai.APIError
 	if errors.As(err, &apiErr) {
 		return map[string]any{
@@ -78,7 +78,7 @@ func extractErrorResponse(err error) any {
 			},
 		}
 	}
-	
+
 	return nil
 }
 
@@ -122,7 +122,7 @@ func (a *App) testProviderModel(ctx context.Context, model Model) error {
 			Messages: []openai.ChatCompletionMessage{
 				{Role: openai.ChatMessageRoleUser, Content: "Hello"},
 			},
-			MaxTokens: 1,
+			MaxCompletionTokens: 1,
 		},
 	}
 	_, err = llmProvider.ChatCompletion(ctx, req)
@@ -178,7 +178,7 @@ func (a *App) llmProviderHealth(ctx context.Context) (llmProviderHealthDetails, 
 	if !anyOK {
 		d.OK = false
 		d.Error = "No functioning models are available"
-		
+
 		var firstErrorResponse any
 		for _, v := range d.Models {
 			if !v.OK && v.Response != nil {

--- a/packages/grafana-llm-frontend/src/llm.ts
+++ b/packages/grafana-llm-frontend/src/llm.ts
@@ -171,9 +171,13 @@ export interface ChatCompletionsRequest {
   /**
    * The maximum number of tokens to generate in the chat completion.
    *
-   * The total length of input tokens and generated tokens is limited by the model's context length. Example Python code for counting tokens.
+   * This value is now deprecated in favor of `max_completion_tokens`.
    */
   max_tokens?: number;
+  /**
+   * An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.
+   */
+  max_completion_tokens?: number;
   /**
    * Number between -2.0 and 2.0.
    *


### PR DESCRIPTION
maxTokens is deprecated and is incompatible with some new models.
maxCompletionTokens is the replacement which works with all models.

See [the OpenAI docs](https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens)
for details on the deprecation, and the
[Anthropic docs](https://docs.anthropic.com/en/api/openai-sdk#request-fields)
which mentions support for both.

Fixes #778.
