### PR TITLE
fix: use higher max tokens for health check

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/health.go
+++ b/packages/grafana-llm-app/pkg/plugin/health.go
@@ -122,7 +122,6 @@ func (a *App) testProviderModel(ctx context.Context, model Model) error {
 			Messages: []openai.ChatCompletionMessage{
 				{Role: openai.ChatMessageRoleUser, Content: "Hello"},
 			},
-			MaxCompletionTokens: 1,
 		},
 	}
 	_, err = llmProvider.ChatCompletion(ctx, req)


### PR DESCRIPTION
It turns out that setting max_completion_tokens causes the request to
_fail_ if the number of tokens to be generated is greater than the
limit, as opposed to max_tokens which just truncated the response.
This causes the health check to fail if it's too low.

This commit gets rid of the max_completion_tokens set in the health
check so that it can't fail for that reason.

GPT 5 works now:

<img width="659" height="1002" alt="image" src="https://github.com/user-attachments/assets/3a8217df-e29c-4c56-a36d-2cae916e9852" />
