### PR TITLE
fix: handle empty response.choices in extractContent of @grafana/llm

### DIFF
--- a/packages/grafana-llm-frontend/src/llm.test.ts
+++ b/packages/grafana-llm-frontend/src/llm.test.ts
@@ -1,6 +1,12 @@
-import { enabled } from "./llm";
+import {
+  enabled,
+  extractContent,
+  ChatCompletionsResponse,
+  ChatCompletionsChunk,
+} from "./llm";
 import { LLM_PLUGIN_ROUTE } from "./constants";
 import { getBackendSrv } from "@grafana/runtime";
+import { of } from "rxjs";
 
 jest.mock("@grafana/runtime", () => ({
   getBackendSrv: jest.fn(),
@@ -35,5 +41,76 @@ describe("enabled", () => {
     // Call the enabled function
     const result = await enabled();
     expect(result).toBe(true);
+  });
+});
+
+describe("extractContent", () => {
+  it("should handle empty choices array without throwing", (done) => {
+    const emptyResponse: ChatCompletionsResponse<ChatCompletionsChunk> = {
+      id: "test-id",
+      object: "chat.completion.chunk",
+      created: Date.now(),
+      model: "test-model",
+      choices: [], // Empty choices array
+      usage: {
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        total_tokens: 0,
+      },
+    };
+
+    const source$ = of(emptyResponse);
+    const result$ = source$.pipe(extractContent());
+
+    const results: string[] = [];
+    result$.subscribe({
+      next: (value) => results.push(value),
+      error: (err) => {
+        // Should not error
+        done(err);
+      },
+      complete: () => {
+        // Should complete successfully with no emitted values
+        expect(results).toEqual([]);
+        done();
+      },
+    });
+  });
+
+  it("should extract content from valid content messages", (done) => {
+    const validResponse: ChatCompletionsResponse<ChatCompletionsChunk> = {
+      id: "test-id",
+      object: "chat.completion.chunk",
+      created: Date.now(),
+      model: "test-model",
+      choices: [
+        {
+          delta: {
+            content: "Hello, world!",
+            role: "assistant" as const,
+          },
+        },
+      ],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+      },
+    };
+
+    const source$ = of(validResponse);
+    const result$ = source$.pipe(extractContent());
+
+    const results: string[] = [];
+    result$.subscribe({
+      next: (value) => results.push(value),
+      error: (err) => {
+        done(err);
+      },
+      complete: () => {
+        expect(results).toEqual(["Hello, world!"]);
+        done();
+      },
+    });
   });
 });

--- a/packages/grafana-llm-frontend/src/llm.ts
+++ b/packages/grafana-llm-frontend/src/llm.ts
@@ -367,8 +367,10 @@ export function extractContent(): UnaryFunction<
   Observable<string>
 > {
   return pipe(
-    filter((response: ChatCompletionsResponse<ChatCompletionsChunk>) =>
-      isContentMessage(response.choices[0].delta),
+    filter(
+      (response: ChatCompletionsResponse<ChatCompletionsChunk>) =>
+        response.choices.length > 0 &&
+        isContentMessage(response.choices[0].delta),
     ),
     // The type assertion is needed here because the type predicate above doesn't seem to propagate.
     map(


### PR DESCRIPTION
Fixes #790.
