### PR TITLE
fix: allow editing URL field in custom mode

### DIFF
--- a/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
@@ -111,7 +111,7 @@ export function OpenAIConfig({
           width={60}
           name="url"
           data-testid={testIds.appConfig.openAIUrl}
-          value={effectiveProvider === 'openai' ? OPENAI_API_URL : settings.url}
+          value={effectiveProvider === 'openai' && parentProvider !== 'custom' ? OPENAI_API_URL : settings.url}
           placeholder={
             effectiveProvider === 'azure'
               ? AZURE_OPENAI_URL_TEMPLATE

--- a/packages/grafana-llm-app/tests/provider-switching.spec.ts
+++ b/packages/grafana-llm-app/tests/provider-switching.spec.ts
@@ -123,6 +123,26 @@ test.describe('Provider Switching UI Consistency', () => {
     await expect(providerDropdown).not.toBeVisible();
   });
 
+  test('should allow editing URL field in custom mode', async ({ page }) => {
+    // Switch to Custom card
+    const customCard = page.locator('text=Use a Custom API').locator('..');
+    await customCard.click();
+    await page.waitForTimeout(500);
+
+    // Verify URL field is visible and enabled
+    const urlField = page.getByTestId(testIds.appConfig.openAIUrl);
+    await expect(urlField).toBeVisible();
+    await expect(urlField).toBeEnabled();
+
+    // Clear any existing value and type a custom URL
+    await urlField.clear();
+    const customUrl = 'https://my-custom-llm-api.example.com';
+    await urlField.fill(customUrl);
+
+    // Verify the URL was set correctly
+    await expect(urlField).toHaveValue(customUrl);
+  });
+
   test('should switch to Anthropic provider correctly', async ({ page }) => {
     // Select Anthropic card
     const anthropicCard = page.locator('text=Use Anthropic API').locator('..');


### PR DESCRIPTION
Hopefully for real this time.

Should fix #800.

Problem:
After the initial fix for #800, the URL field in custom mode was read-only.
Users could not edit the URL when using a custom API provider, despite the
field appearing enabled.

Root Cause:
The URL field's value was set based on effectiveProvider === 'openai', which
defaults to 'openai' when settings.openAI.provider is undefined (for
consistency). This meant in custom mode, the field always showed the hardcoded
OPENAI_API_URL value instead of allowing settings.url to be editable.

Solution:
Updated the value logic to also check parentProvider:
  value={effectiveProvider === 'openai' && parentProvider !== 'custom'
    ? OPENAI_API_URL
    : settings.url}

This ensures:
- OpenAI card + openai provider: Shows hardcoded OPENAI_API_URL (read-only)
- OpenAI card + azure provider: Shows settings.url (editable)
- Custom card: Shows settings.url (editable), even when effectiveProvider='openai'

Testing:
Added new e2e test 'should allow editing URL field in custom mode' that:
1. Switches to custom provider
2. Clears and types a new URL
3. Verifies the URL was updated

All 8 e2e tests now pass (including the new test).
