### PR TITLE
fix(iam): add missing write permissions for MCP tools

### DIFF
--- a/packages/grafana-llm-app/src/plugin.json
+++ b/packages/grafana-llm-app/src/plugin.json
@@ -69,7 +69,26 @@
         "scope": "folders:*"
       },
       {
+        "action": "folders:create"
+      },
+      {
+        "action": "folders:write",
+        "scope": "folders:*"
+      },
+      {
         "action": "alert.rules:read",
+        "scope": "folders:*"
+      },
+      {
+        "action": "alert.rules:create",
+        "scope": "folders:*"
+      },
+      {
+        "action": "alert.rules:write",
+        "scope": "folders:*"
+      },
+      {
+        "action": "alert.rules:delete",
         "scope": "folders:*"
       },
       {


### PR DESCRIPTION
## Summary

- Add missing IAM permissions for the plugin's managed service account that are required by MCP write tools
- Fixes `403 Forbidden` errors when MCP tools attempt write operations (e.g., `create_alert_rule`, `update_dashboard`)

## Problem

The plugin registers MCP tools with write operations enabled (`AddAlertingTools(srv, true)`, `AddDashboardTools(srv, true)`), but the managed service account declared in `plugin.json` only has read permissions for alert rules and folders. This causes:

- **Alert rule tools fail**: `create_alert_rule`, `update_alert_rule`, `delete_alert_rule` all return 403 because only `alert.rules:read` is declared
- **Dashboard save fails**: `update_dashboard` returns `"Access denied to save dashboard"` because the service account lacks folder write permissions needed for dashboard creation/updates

## Changes

Added 5 missing IAM permissions to `plugin.json`:

| Permission | Scope | Required by |
|---|---|---|
| `alert.rules:create` | `folders:*` | `create_alert_rule` tool |
| `alert.rules:write` | `folders:*` | `update_alert_rule` tool |
| `alert.rules:delete` | `folders:*` | `delete_alert_rule` tool |
| `folders:create` | — | `update_dashboard` (creating dashboards in folders) |
| `folders:write` | `folders:*` | `update_dashboard` (saving dashboards to existing folders) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)