### PR TITLE
fix(iam): correct scope for dashboards:create and add alert provisioning permission

### DIFF
--- a/packages/grafana-llm-app/src/plugin.json
+++ b/packages/grafana-llm-app/src/plugin.json
@@ -58,7 +58,7 @@
       },
       {
         "action": "dashboards:create",
-        "scope": "dashboards:*"
+        "scope": "folders:uid:*"
       },
       {
         "action": "dashboards:write",
@@ -90,6 +90,9 @@
       {
         "action": "alert.rules:delete",
         "scope": "folders:*"
+      },
+      {
+        "action": "alert.provisioning.provenance:write"
       },
       {
         "action": "alert.notifications:read"


### PR DESCRIPTION
## Summary

Fixes two IAM permission issues in `plugin.json` that prevent the service account from creating dashboards and alert rules via `mcp-grafana` tools:

- **`dashboards:create` scope mismatch**: Changed scope from `dashboards:*` to `folders:uid:*` because Grafana's `POST /api/dashboards/db` handler evaluates `dashboards:create` against `folders:uid:<folderUID>` (dashboards are created within folders, not at the dashboard scope level)
- **Missing `alert.provisioning.provenance:write`**: The provisioning API (`POST /api/v1/provisioning/alert-rules`) requires either `alert.provisioning:write`, `alert.rules.provisioning:write`, or **both** `alert.rules:create` AND `alert.provisioning.provenance:write`. The IAM block declared `alert.rules:create` but was missing the companion `alert.provisioning.provenance:write` permission

## Root Cause

**Dashboard creation (403):**
```
Evaluating permissions  id=service-account:3 orgID=1
  permissions="action:dashboards:create scopes:folders:uid:general"
POST /api/dashboards/db status=403 error="Access denied to save dashboard"
```
The SA has `dashboards:create` scoped to `dashboards:*`, but Grafana checks against `folders:uid:general` — scope mismatch.

**Alert creation (403):**
```
Permissions needed: any of alert.provisioning:write,
  alert.rules.provisioning:write,
  all of alert.rules:create, alert.provisioning.provenance:write
```
The SA has `alert.rules:create` but not `alert.provisioning.provenance:write`, so the granular authorization path fails.

## Test plan

Tested against Grafana 12.2.0 with a service account using the fixed IAM permissions:

- [x] **Before fix**: Dashboard creation → 403 `Access denied to save dashboard`
- [x] **Before fix**: Alert rule creation → 403 `Permissions needed: any of alert.provisioning:write...`
- [x] **After fix**: Dashboard creation → 200 success
- [x] **After fix**: Alert rule creation → 201 created
- [x] Existing read permissions unaffected
- [x] Other write permissions (folders, alert rules write/delete) unaffected

## References

- Grafana dashboard RBAC: `pkg/services/dashboards/service/dashboard_service.go` (`canCreateDashboard` checks `folders:uid:<folderUID>`)
- Grafana alert provisioning RBAC: `pkg/services/ngalert/api/authorization.go` (provisioning endpoint requires `alert.provisioning.provenance:write` for granular path)
- `mcp-grafana` dashboard tool: `tools/dashboard.go` → `POST /api/dashboards/db`
- `mcp-grafana` alerting tool: `tools/alerting.go` → `POST /api/v1/provisioning/alert-rules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)