### PR TITLE
chore: replace grafana-incident-app with grafana-irm-app in MCP server URLs

### DIFF
--- a/packages/grafana-llm-app/pkg/mcp/http_server.go
+++ b/packages/grafana-llm-app/pkg/mcp/http_server.go
@@ -124,7 +124,7 @@ func (m *MCP) extractIncidentClientFromHTTPRequest(ctx context.Context, req *htt
 		return ctx
 	}
 	apiKey, _ := cfg.PluginAppClientSecret()
-	incidentUrl := fmt.Sprintf("%s/api/plugins/grafana-incident-app/resources/api/", strings.TrimSuffix(grafanaURL, "/"))
+	incidentUrl := fmt.Sprintf("%s/api/plugins/grafana-irm-app/resources/api/", strings.TrimSuffix(grafanaURL, "/"))
 	// TODO: incident client does not support access tokens. For this reason,
 	// we will not be enabling Incident tools in Grafana Cloud yet.
 	client := incident.NewClient(incidentUrl, apiKey)

--- a/packages/grafana-llm-app/pkg/mcp/live_server.go
+++ b/packages/grafana-llm-app/pkg/mcp/live_server.go
@@ -265,7 +265,7 @@ func extractIncidentClientFromGrafanaLiveRequest(ctx context.Context, pCtx *back
 		return ctx
 	}
 	apiKey, _ := cfg.PluginAppClientSecret()
-	incidentUrl := fmt.Sprintf("%s/api/plugins/grafana-incident-app/resources/api/", strings.TrimSuffix(grafanaURL, "/"))
+	incidentUrl := fmt.Sprintf("%s/api/plugins/grafana-irm-app/resources/api/", strings.TrimSuffix(grafanaURL, "/"))
 	// TODO: incident client does not support access tokens. For this reason,
 	// we will not be enabling Incident tools in Grafana Cloud yet.
 	client := incident.NewClient(incidentUrl, apiKey)


### PR DESCRIPTION
The Incident app is decommisioned in favour of the IRM app.
