### PR TITLE
Add ignore-scripts option to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @grafana:registry=https://registry.npmjs.org
+ignore-scripts=true


### PR DESCRIPTION
This PR is adding the ignore-scripts directive to npm so that we are not running any lifecycle scripts from the dependencies. 