### PR TITLE
fix(deps): bump Go to 1.26.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       id-token: write
       attestations: write
     with:
-      go-version: "1.26.1"
+      go-version: "1.26.2"
       golangci-lint-version: "2.11.4"
       node-version: "22"
       plugin-directory: packages/grafana-llm-app

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
       attestations: write
     with:
-      go-version: "1.26.1"
+      go-version: "1.26.2"
       golangci-lint-version: "2.11.4"
       node-version: "22"
       plugin-directory: packages/grafana-llm-app

--- a/llmclient/go.mod
+++ b/llmclient/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/grafana-llm-app/llmclient
 
-go 1.25.9
+go 1.26.2
 
 require github.com/sashabaranov/go-openai v1.41.2

--- a/packages/grafana-llm-app/go.mod
+++ b/packages/grafana-llm-app/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-llm-app
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.32.0


### PR DESCRIPTION
## Summary
- Bump Go version from 1.26.1 to 1.26.2 in the main plugin module (`packages/grafana-llm-app/go.mod`)
- Bump Go version from 1.25.9 to 1.26.2 in the llmclient module (`llmclient/go.mod`)
- Addresses security fixes included in Go 1.26.2

## Test plan
- [ ] CI passes with new Go version
- [ ] `go vet ./...` passes in both modules (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)