### PR TITLE
fix(deps): add override for protocol-buffers-schema 3.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15862,9 +15862,10 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "dompurify": "3.4.0",
     "immutable": "5.1.5",
     "protobufjs": "8.0.1",
+    "protocol-buffers-schema": "3.6.1",
     "sass": {
       "immutable": "4.3.8"
     }


### PR DESCRIPTION
## Summary
- Adds an npm override for `protocol-buffers-schema` to pin version 3.6.1
- Addresses [GHSA-j452-xhg8-qg39](https://github.com/advisories/GHSA-j452-xhg8-qg39) (prototype pollution in protocol-buffers-schema < 3.6.1)
- This is a transitive dependency via `@grafana/data` -> `ol` -> `pbf` -> `resolve-protobuf-schema` -> `protocol-buffers-schema`

## Test plan
- [ ] Verify `npm ls protocol-buffers-schema` shows 3.6.1
- [ ] Verify `npm audit` no longer reports GHSA-j452-xhg8-qg39
- [ ] CI passes (build + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)