### PR TITLE
fix(ci): add --provenance flag to npm publish

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -64,4 +64,4 @@ jobs:
       - name: Publish to NPM
         run: |
           cd packages/grafana-llm-frontend
-          npm publish --access public
+          npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- Follows up on #900 which downgraded the npm self-upgrade from ^11.5.1 to ^10.9.0
- npm 10.x requires `--provenance` to be passed explicitly for Trusted Publishing to work — npm 11 enabled it by default, which is why it was missing
- Without the flag, publish falls back to token auth and fails with a 404

## Test plan
- [ ] Merge and re-run the [npm-release workflow](https://github.com/grafana/grafana-llm-app/actions/workflows/npm-release.yml) — the publish step should now authenticate via OIDC and succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)