### PR TITLE
feat: allow custom model strings to avoid unrecognized model error

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/llm_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider.go
@@ -21,23 +21,26 @@ const (
 	ModelLarge = "large"
 )
 
-// UnmarshalJSON accepts either OpenAI named models for backwards
-// compatability, or the new abstract model names.
 func ModelFromString(m string) (Model, error) {
+	if m == "" {
+		return "", fmt.Errorf("model name cannot be empty")
+	}
 	switch {
 	case m == ModelLarge || (strings.HasPrefix(m, "gpt-4") && !strings.Contains(m, "-mini")):
 		return ModelLarge, nil
 	case m == ModelBase || strings.HasPrefix(m, "gpt-3.5") || strings.Contains(m, "-mini"):
 		return ModelBase, nil
 	}
-	// TODO: Give users the ability to specify a default model abstraction in settings, and use that here.
-	return "", fmt.Errorf("unrecognized model: %s", m)
+	return Model(m), nil
 }
 
 // UnmarshalJSON accepts either OpenAI named models for backwards
 // compatability, or the new abstract model names.
 func (m *Model) UnmarshalJSON(data []byte) error {
 	dataString := string(data)
+	if dataString == `""` || dataString == `null` {
+		return fmt.Errorf("model name cannot be empty")
+	}
 	switch {
 	case dataString == fmt.Sprintf(`"%s"`, ModelLarge) || strings.HasPrefix(dataString, `"gpt-4`):
 		*m = ModelLarge
@@ -46,8 +49,9 @@ func (m *Model) UnmarshalJSON(data []byte) error {
 		*m = ModelBase
 		return nil
 	}
-	// TODO: Give users the ability to specify a default model abstraction in settings, and use that here.
-	return fmt.Errorf("unrecognized model: %s", dataString)
+	unquoted := strings.Trim(dataString, `"`)
+	*m = Model(unquoted)
+	return nil
 }
 
 func (m Model) toOpenAI(modelSettings *ModelSettings) string {

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider_test.go
@@ -29,9 +29,9 @@ func TestModelFromString(t *testing.T) {
 
 		// unknown models
 		{
-			input:    "invalid_model",
-			expected: "",
-			wantErr:  true,
+			input:    "custom_model",
+			expected: Model("custom_model"),
+			wantErr:  false,
 		},
 		{
 			input:    "",
@@ -120,9 +120,9 @@ func TestModelUnmarshalJSON(t *testing.T) {
 
 		// unknown models
 		{
-			input:    []byte(`"invalid_model"`),
-			expected: "",
-			wantErr:  true,
+			input:    []byte(`"custom_model"`),
+			expected: Model("custom_model"),
+			wantErr:  false,
 		},
 		{
 			input:    []byte(`""`),


### PR DESCRIPTION
This PR implements an enhancement to the LLM client by resolving the backend TODOs in `llm_provider.go`. It allows custom, unrecognized model strings to safely pass through parsing instead of erroring, enabling them to map dynamically or safely fall back to default models configured in settings.

### Changes:
1. **Support Unrecognized Model Strings**: Modified `ModelFromString` and `UnmarshalJSON` in `llm_provider.go` to successfully parse non-empty custom model strings as `Model(m)` instead of throwing an error.
2. **Enable Dynamic Fallbacks**: Allows custom default models specified in the settings to be used properly, integrating cleanly with existing mapping fallbacks.
3. **Test Adaptations**: Updated `llm_provider_test.go` to assert that custom model strings are successfully preserved rather than treated as errors.

Signed-off-by: ArunKG <g.arunkumar27@gmail.com>