### PR TITLE
feat(openai): add configurable auth header name for OpenAI-compatible proxies

### DIFF
--- a/packages/grafana-llm-app/.config/webpack/webpack.config.ts
+++ b/packages/grafana-llm-app/.config/webpack/webpack.config.ts
@@ -81,7 +81,7 @@ const config = async (env): Promise<Configuration> => ({
           loader: 'swc-loader',
           options: {
             jsc: {
-              baseUrl: path.resolve(__dirname, 'src'),
+              baseUrl: path.resolve(process.cwd(), SOURCE_DIR),
               target: 'es2015',
               loose: false,
               parser: {

--- a/packages/grafana-llm-app/pkg/plugin/openai_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/openai_provider.go
@@ -7,11 +7,32 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/sashabaranov/go-openai"
 )
+
+// customAuthTransport injects the configured auth header on every request.
+// go-openai sets "Authorization: Bearer <token>" inside sendRequest before calling HTTPClient.Do,
+// so we pass DefaultConfig("") (empty token) and let this transport override the header.
+type customAuthTransport struct {
+	base       http.RoundTripper
+	headerName string
+	apiKey     string
+}
+
+func (t *customAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r2 := req.Clone(req.Context())
+	r2.Header.Del("Authorization") // remove the empty "Bearer " set by DefaultConfig("")
+	if strings.EqualFold(t.headerName, "Authorization") {
+		r2.Header.Set("Authorization", "Bearer "+t.apiKey)
+	} else {
+		r2.Header.Set(t.headerName, t.apiKey)
+	}
+	return t.base.RoundTrip(r2)
+}
 
 type openAI struct {
 	settings OpenAISettings
@@ -20,23 +41,33 @@ type openAI struct {
 }
 
 func NewOpenAIProvider(settings OpenAISettings, models *ModelSettings) (LLMProvider, error) {
-	client := &http.Client{
-		Timeout: 2 * time.Minute,
-	}
-	cfg := openai.DefaultConfig(settings.apiKey)
-
 	// Defensively check that APIPath is not nil to avoid potential panics
 	// if settings aren't loaded using loadSettings.
 	if settings.APIPath == nil {
-		*settings.APIPath = defaultOpenAIAPIPath
+		settings.APIPath = &defaultOpenAIAPIPath
+	}
+	if settings.AuthHeaderName == "" {
+		settings.AuthHeaderName = "Authorization"
 	}
 
+	httpClient := &http.Client{
+		Timeout: 2 * time.Minute,
+		Transport: &customAuthTransport{
+			base:       http.DefaultTransport,
+			headerName: settings.AuthHeaderName,
+			apiKey:     settings.apiKey,
+		},
+	}
+
+	// Pass empty auth token so go-openai doesn't set its own Authorization header;
+	// customAuthTransport handles auth injection for all header name variants.
+	cfg := openai.DefaultConfig("")
 	base, err := url.JoinPath(settings.URL, *settings.APIPath)
 	if err != nil {
 		return nil, fmt.Errorf("join url: %w", err)
 	}
 	cfg.BaseURL = base
-	cfg.HTTPClient = client
+	cfg.HTTPClient = httpClient
 	cfg.OrgID = settings.OrganizationID
 	return &openAI{
 		settings: settings,

--- a/packages/grafana-llm-app/pkg/plugin/settings.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings.go
@@ -48,6 +48,11 @@ type OpenAISettings struct {
 	// The OrgID to be passed to OpenAI in requests
 	OrganizationID string `json:"organizationId"`
 
+	// AuthHeaderName is the HTTP header used to send the API key. Defaults to "Authorization",
+	// which uses the standard "Bearer <key>" format. Set to a custom value (e.g. "x-litellm-api-key")
+	// for proxies that expect the raw key in a non-standard header.
+	AuthHeaderName string `json:"authHeaderName"`
+
 	// What OpenAI provider the user selected. Note this can specify using the LLMGateway
 	// Deprecated: Use Settings.Provider instead
 	Provider ProviderType `json:"provider"`
@@ -315,12 +320,16 @@ func loadSettings(appSettings backend.AppInstanceSettings) (*Settings, error) {
 	if settings.OpenAI.APIPath == nil {
 		settings.OpenAI.APIPath = &defaultOpenAIAPIPath
 	}
+	if settings.OpenAI.AuthHeaderName == "" {
+		settings.OpenAI.AuthHeaderName = "Authorization"
+	}
 	if settings.Anthropic.URL == "" {
 		settings.Anthropic.URL = "https://api.anthropic.com"
 	}
 	if settings.Vector.Embed.Type == embed.EmbedderOpenAI {
 		settings.Vector.Embed.OpenAI.URL = settings.OpenAI.URL
 		settings.Vector.Embed.OpenAI.AuthType = "openai-key-auth"
+		settings.Vector.Embed.OpenAI.AuthHeaderName = settings.OpenAI.AuthHeaderName
 	}
 
 	provider := settings.getEffectiveProvider()

--- a/packages/grafana-llm-app/pkg/plugin/vector/embed/embedder.go
+++ b/packages/grafana-llm-app/pkg/plugin/vector/embed/embedder.go
@@ -25,6 +25,7 @@ type Settings struct {
 	GrafanaVectorAPISettings grafanaVectorAPISettings `json:"grafanaVectorAPI"`
 }
 
+
 // NewEmbedder creates a new embedder.
 func NewEmbedder(s Settings, secrets map[string]string) (Embedder, error) {
 	log.DefaultLogger.Debug("Creating OpenAI embedder")

--- a/packages/grafana-llm-app/pkg/plugin/vector/embed/openai.go
+++ b/packages/grafana-llm-app/pkg/plugin/vector/embed/openai.go
@@ -13,8 +13,9 @@ import (
 )
 
 type openAISettings struct {
-	URL      string
-	AuthType string
+	URL            string
+	AuthType       string
+	AuthHeaderName string
 }
 
 type grafanaVectorAPISettings struct {
@@ -30,11 +31,12 @@ type openAIEmbeddingsAuthSettings struct {
 }
 
 type openAIClient struct {
-	client       *http.Client
-	url          string
-	authType     string
-	providerType EmbedderType
-	authSettings openAIEmbeddingsAuthSettings
+	client         *http.Client
+	url            string
+	authType       string
+	authHeaderName string
+	providerType   EmbedderType
+	authSettings   openAIEmbeddingsAuthSettings
 }
 
 type openAIEmbeddingsRequest struct {
@@ -55,9 +57,16 @@ func (o *openAIClient) setAuth(req *http.Request) {
 	case "basic-auth":
 		req.SetBasicAuth(o.authSettings.BasicAuthUser, o.authSettings.BasicAuthPassword)
 	case "openai-key-auth":
-		req.Header.Add("Authorization", "Bearer "+o.authSettings.OpenAIKey)
+		headerName := o.authHeaderName
+		if headerName == "" {
+			headerName = "Authorization"
+		}
+		if strings.EqualFold(headerName, "Authorization") {
+			req.Header.Add("Authorization", "Bearer "+o.authSettings.OpenAIKey)
+		} else {
+			req.Header.Add(headerName, o.authSettings.OpenAIKey)
+		}
 	}
-
 }
 
 func (o *openAIClient) getProviderString() string {
@@ -132,10 +141,11 @@ func newOpenAIEmbedder(settings Settings, secrets map[string]string) Embedder {
 	switch settings.Type {
 	case EmbedderOpenAI:
 		impl = openAIClient{
-			client:       &http.Client{},
-			url:          settings.OpenAI.URL,
-			authType:     string(settings.OpenAI.AuthType),
-			providerType: settings.Type,
+			client:         &http.Client{},
+			url:            settings.OpenAI.URL,
+			authType:       string(settings.OpenAI.AuthType),
+			authHeaderName: settings.OpenAI.AuthHeaderName,
+			providerType:   settings.Type,
 			authSettings: openAIEmbeddingsAuthSettings{
 				OpenAIKey: secrets["openAIKey"],
 			},

--- a/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
@@ -25,6 +25,10 @@ export interface OpenAISettings {
   azureModelMapping?: AzureModelDeployments;
   // If the LLM features have been explicitly disabled.
   disabled?: boolean;
+  // The HTTP header used to send the API key.
+  // Defaults to "Authorization" (Bearer format). Set to a custom value such as
+  // "x-litellm-api-key" for proxies that expect the raw key in a non-standard header.
+  authHeaderName?: string;
 }
 
 export function OpenAIConfig({
@@ -163,6 +167,22 @@ export function OpenAIConfig({
           onReset={() => onChangeSecrets({ ...secrets, openAIKey: '' })}
         />
       </Field>
+
+      {parentProvider === 'custom' && (
+        <Field
+          label="Auth Header Name"
+          description="HTTP header used to send the API key. Defaults to 'Authorization' (Bearer format). Use a custom value such as 'x-litellm-api-key' for proxies that expect the raw key in a non-standard header."
+          className={s.marginTop}
+        >
+          <Input
+            width={40}
+            name="authHeaderName"
+            placeholder="Authorization"
+            value={settings.authHeaderName ?? ''}
+            onChange={onChangeField}
+          />
+        </Field>
+      )}
 
       {effectiveProvider === 'openai' && (
         <Field label="API Organization ID">


### PR DESCRIPTION
  ## Summary

  Adds an optional `authHeaderName` setting for the OpenAI provider that lets users configure
  which HTTP header carries the API key. This is needed for proxies like LiteLLM that expect
  the key in a custom header (e.g. `x-litellm-api-key`) rather than `Authorization: Bearer <key>`.

  ## Changes

  - **`settings.go`**: Added `AuthHeaderName` to `OpenAISettings` (defaults to `"Authorization"`);
    propagates to the vector embedder settings.
  - **`openai_provider.go`**: Introduced `customAuthTransport` that removes the empty
    `Authorization` header set by `go-openai`'s `DefaultConfig("")` and injects the correct
    header instead. Also fixed a nil pointer dereference on `APIPath`.
  - **`vector/embed/openai.go`**: Extended `setAuth()` to use `AuthHeaderName`; raw key is sent
    for non-`Authorization` headers, `Bearer <key>` for the standard header.
  - **`AppConfig/OpenAI.tsx`**: Added `authHeaderName` UI field, shown only when `custom` provider
    is selected.
  - **`webpack.config.ts`**: Fixed `baseUrl` to use `process.cwd()` + `SOURCE_DIR` instead of
    `__dirname` (which resolves incorrectly when config is in `.config/`).

  ## Testing

  - Verified with a LiteLLM proxy using `x-litellm-api-key` header — completions and embeddings
    both succeed with the custom header.
  - Standard OpenAI usage with `Authorization: Bearer` header is unchanged.