### PR TITLE
(fix CVE-2026-4800): override nested @grafana/ui/lodash to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2514,13 +2514,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@grafana/ui/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@grafana/ui/node_modules/uuid": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
@@ -5683,9 +5676,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5703,9 +5693,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5723,9 +5710,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5743,9 +5727,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5763,9 +5744,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5783,9 +5761,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -15642,6 +15617,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "@isaacs/brace-expansion": "5.0.1",
     "diff": "9.0.0",
     "lodash": "4.18.1",
+    "@grafana/ui": {
+      "lodash": "4.18.1"
+    },
     "dompurify": "3.4.1",
     "immutable": "5.1.5",
     "protobufjs": "8.0.1",


### PR DESCRIPTION
Related to [this](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/1558/version/20352/cve/53387493)