### PR TITLE
chore(ci): scope Vault secrets to the token step in version-bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -33,6 +33,11 @@ jobs:
           VAULT_INSTANCE: ops
         with:
           vault_instance: ${{ env.VAULT_INSTANCE }}
+          # Don't export secrets to the job-wide environment; consume them via this
+          # step's `secrets` output only in the step that needs them (below). This keeps
+          # the GitHub App private key out of the env of later steps that run third-party
+          # code (npm install, npx generate-changelog).
+          export_env: false
           common_secrets: |
             GITHUB_APP_ID=plugins-platform-bot-app:app-id
             GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
@@ -41,8 +46,8 @@ jobs:
         id: generate-github-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
+          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What

Hardens `.github/workflows/version-bump.yml` so the `grafana-plugins-platform-bot` GitHub App credentials fetched from Vault are no longer exported to the job-wide environment.

- Adds `export_env: false` to the `grafana/shared-workflows/actions/get-vault-secrets` step.
- Reads the two credentials from the action's step output — `${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}` / `...GITHUB_APP_PRIVATE_KEY }}` — only in the `actions/create-github-app-token` step that needs them.

## Why

Part of the AI/repo GitHub Actions hardening tracked in grafana/grafana-assistant-app#6947, applying the relevant half of the pattern from grafana/grafana-assistant-app#7020.

With the default `export_env: true`, the App **private key** lands in the environment of the entire `bump-version` job — including the later `Regenerate lock file` (`npm install --package-lock-only`) and `Generate changelog` (`npx generate-changelog`) steps, which execute third-party code. Scoping the raw credentials to the single token-minting step reduces the blast radius of that long-lived credential.

**The actor-trust (`author_association`) half of #7020 is not applicable here:** this repo has no `issue_comment` / `pull_request_review` / `issues`-triggered workflows and no Claude/AI automation. The only secret-fetching workflow is `workflow_dispatch`-only, which GitHub already restricts to actors with write access.

## No behavior change

The same App token is minted and every downstream step keeps using `steps.generate-github-token.outputs.token`. Verified against the action source (`grafana/shared-workflows` `actions/get-vault-secrets/action.yaml`):

- `outputs.secrets` is `toJSON(steps.import-secrets.outputs)` and is populated **independently** of `export_env` (the underlying `hashicorp/vault-action` always sets per-secret outputs; `exportEnv` only toggles the extra env write).
- Output keys are exactly the LHS env-var names (`GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`), per `translate-secrets.bash`.
- The multiline PEM private key round-trips safely through `toJSON`/`fromJSON`; values stay `setSecret`-masked in logs.
- A repo-wide grep confirms these were the **only** consumers of `env.GITHUB_APP_*`.

## Test plan

- [x] Diff is exactly 3 changed lines (+ explanatory comment); no remaining `env.GITHUB_APP_*` references.
- [x] Workflow YAML parses cleanly (`js-yaml`); parsed fields confirm `export_env: false` and the two rewired inputs.
- [ ] After merge: run **"Version bump and update changelog"** via `workflow_dispatch` (`version: patch`, `generate-changelog: true`) and confirm the token-generation, version-bump, changelog, commit/push, and tag steps all succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)