### PR TITLE
fix(live): set both stream and namespace on plugin Live channels

### DIFF
--- a/packages/grafana-llm-frontend/src/constants.ts
+++ b/packages/grafana-llm-frontend/src/constants.ts
@@ -1,9 +1,32 @@
+import { LiveChannelAddress, LiveChannelScope } from "@grafana/data";
 import { logWarning } from "@grafana/runtime";
 
 import { SemVer } from "semver";
 
 export const LLM_PLUGIN_ID = "grafana-llm-app";
 export const LLM_PLUGIN_ROUTE = `/api/plugins/${LLM_PLUGIN_ID}`;
+
+// Grafana 12.4 renamed `LiveChannelAddress.namespace` to `stream` and now
+// builds the channel id from `stream`, ignoring `namespace`. Older versions do
+// the reverse. We must set both so a single plugin build subscribes to the
+// correct channel regardless of which Grafana version is running; omitting
+// `stream` on 12.4+ yields a `plugin/undefined/...` channel that never routes.
+// The intersection adds `stream` to the type without losing type checking on
+// the other fields, even when building against a pre-12.4 `@grafana/data`.
+type PluginLiveChannelAddress = LiveChannelAddress & { stream: string };
+
+export function pluginLiveChannel(
+  path: string,
+  data?: unknown,
+): PluginLiveChannelAddress {
+  return {
+    scope: LiveChannelScope.Plugin,
+    namespace: LLM_PLUGIN_ID,
+    stream: LLM_PLUGIN_ID,
+    path,
+    data,
+  };
+}
 
 // The LLM app was at version 0.2.0 before we added the health check.
 // If the health check fails, or the details don't exist on the response,

--- a/packages/grafana-llm-frontend/src/llm.test.ts
+++ b/packages/grafana-llm-frontend/src/llm.test.ts
@@ -1,15 +1,17 @@
 import {
   enabled,
   extractContent,
+  streamChatCompletions,
   ChatCompletionsResponse,
   ChatCompletionsChunk,
 } from "./llm";
-import { LLM_PLUGIN_ROUTE } from "./constants";
-import { getBackendSrv } from "@grafana/runtime";
+import { LLM_PLUGIN_ID, LLM_PLUGIN_ROUTE } from "./constants";
+import { getBackendSrv, getGrafanaLiveSrv } from "@grafana/runtime";
 import { of } from "rxjs";
 
 jest.mock("@grafana/runtime", () => ({
   getBackendSrv: jest.fn(),
+  getGrafanaLiveSrv: jest.fn(),
 }));
 
 describe("enabled", () => {
@@ -41,6 +43,22 @@ describe("enabled", () => {
     // Call the enabled function
     const result = await enabled();
     expect(result).toBe(true);
+  });
+});
+
+describe("streamChatCompletions", () => {
+  it("subscribes via a channel carrying both stream and namespace", () => {
+    const getStream = jest.fn().mockReturnValue(of());
+    (getGrafanaLiveSrv as jest.Mock).mockReturnValue({ getStream });
+
+    streamChatCompletions({ model: "large", messages: [] });
+
+    // Grafana >= 12.4 builds the channel id from `stream`; older versions use
+    // `namespace`. Both must be set so the subscribe routes on every version.
+    const channel = getStream.mock.calls[0][0];
+    expect(channel.stream).toBe(LLM_PLUGIN_ID);
+    expect(channel.namespace).toBe(LLM_PLUGIN_ID);
+    expect(channel.path).toMatch(/^llm\/v1\/chat\/completions\//);
   });
 });
 

--- a/packages/grafana-llm-frontend/src/llm.ts
+++ b/packages/grafana-llm-frontend/src/llm.ts
@@ -10,9 +10,7 @@
 
 import {
   isLiveChannelMessageEvent,
-  LiveChannelAddress,
   LiveChannelMessageEvent,
-  LiveChannelScope,
 } from "@grafana/data";
 import {
   getBackendSrv,
@@ -27,8 +25,8 @@ import { filter, map, scan, takeWhile, tap, toArray } from "rxjs/operators";
 import { v4 as uuidv4 } from "uuid";
 
 import {
-  LLM_PLUGIN_ID,
   LLM_PLUGIN_ROUTE,
+  pluginLiveChannel,
   setLLMPluginVersion,
 } from "./constants";
 import { HealthCheckResponse, LLMProviderHealthDetails } from "./types";
@@ -450,12 +448,10 @@ export async function chatCompletions(
 export function streamChatCompletions(
   request: ChatCompletionsRequest,
 ): Observable<ChatCompletionsResponse<ChatCompletionsChunk>> {
-  const channel: LiveChannelAddress = {
-    scope: LiveChannelScope.Plugin,
-    namespace: LLM_PLUGIN_ID,
-    path: LLM_CHAT_COMPLETIONS_PATH + "/" + uuidv4(),
-    data: request,
-  };
+  const channel = pluginLiveChannel(
+    LLM_CHAT_COMPLETIONS_PATH + "/" + uuidv4(),
+    request,
+  );
   const messages = getGrafanaLiveSrv()
     .getStream(channel)
     .pipe(filter((event) => isLiveChannelMessageEvent(event))) as Observable<

--- a/packages/grafana-llm-frontend/src/mcp.tsx
+++ b/packages/grafana-llm-frontend/src/mcp.tsx
@@ -4,7 +4,6 @@ import {
   isLiveChannelMessageEvent,
   LiveChannelAddress,
   LiveChannelMessageEvent,
-  LiveChannelScope,
 } from "@grafana/data";
 import {
   config,
@@ -24,7 +23,11 @@ import {
 import { Observable, filter } from "rxjs";
 import { v4 as uuid } from "uuid";
 
-import { LLM_PLUGIN_ID, LLM_PLUGIN_ROUTE } from "./constants";
+import {
+  LLM_PLUGIN_ID,
+  LLM_PLUGIN_ROUTE,
+  pluginLiveChannel,
+} from "./constants";
 import { Tool as OpenAITool } from "./openai";
 
 const MCP_GRAFANA_PATH = "mcp/grafana";
@@ -68,16 +71,8 @@ export class GrafanaLiveTransport implements Transport {
       const pathId = uuid();
       path = `${MCP_GRAFANA_PATH}/${pathId}`;
     }
-    this._subscribeChannel = {
-      scope: LiveChannelScope.Plugin,
-      namespace: LLM_PLUGIN_ID,
-      path: `${path}/subscribe`,
-    };
-    this._publishChannel = {
-      scope: LiveChannelScope.Plugin,
-      namespace: LLM_PLUGIN_ID,
-      path: `${path}/publish`,
-    };
+    this._subscribeChannel = pluginLiveChannel(`${path}/subscribe`);
+    this._publishChannel = pluginLiveChannel(`${path}/publish`);
   }
 
   async start(): Promise<void> {


### PR DESCRIPTION
## Problem

On Grafana **≥ 12.4**, plugin-scoped Grafana Live subscriptions from this plugin (LLM streaming via `streamChatCompletions`, and the MCP `GrafanaLiveTransport`) silently fail. The visible symptom is the **"✨ Auto-generate title/description"** button timing out after 10s with `LLM stream timed out`, and **no `subscribe` frame** for the plugin channel on the WebSocket.

## Root cause

grafana/grafana#117275 (*"Live: Use namespace rather than OrgID"*, in 12.4) renamed `LiveChannelAddress.namespace` → `stream` and changed the frontend to build the channel id from `stream`:

```js
// public/app/features/live/centrifuge/service.ts
const id = `${this.deps.namespace}/${addr.scope}/${addr.stream}/${addr.path}`;
```

This plugin only set the (now-deprecated) `namespace` field, so on 12.4+ `addr.stream` is `undefined` and the channel id becomes:

```
default/plugin/undefined/llm/v1/chat/completions/<uuid>
```

which never routes to the plugin's `SubscribeStream`/`RunStream`. Grafana's `namespace → stream` back-compat shim (`isValidLiveChannelAddress`) runs *after* the id is already built, so it doesn't rescue this path. On Grafana < 12.4 the old code reads `namespace`, so it worked there — matching the reporter's 12.3.3-works / 12.4.3-breaks bisection.

## Fix

Set **both** `stream` and `namespace` (to the same plugin id) via a shared `pluginLiveChannel` helper, so a single plugin build subscribes to the correct channel on both old (`namespace`-reading) and new (`stream`-reading) Grafana. A `LiveChannelAddress & { stream: string }` intersection type keeps this fully type-checked even when building against the pinned pre-12.4 `@grafana/data` (whose `LiveChannelAddress` type has no `stream` field) — no cast needed.

Applied to all three channel construction sites:
- `streamChatCompletions` (`llm.ts`)
- `GrafanaLiveTransport` subscribe/publish channels (`mcp.tsx`)

## Notes

- This is the **plugin-side** fix and works against already-shipped Grafana 12.4.x. The underlying Grafana bug (channel id built before namespace→stream normalization) still affects any plugin using the deprecated `namespace` field and is worth fixing upstream too.
- Added a regression test asserting `streamChatCompletions` subscribes via a channel carrying **both** `stream` and `namespace`.

## Testing

- `tsc --noEmit` — clean
- `eslint` — clean
- `jest` — 28/28 pass (incl. new regression test)

Ref: https://github.com/grafana/grafana/issues/125801

🤖 Generated with [Claude Code](https://claude.com/claude-code)