### PR TITLE
ci: open a PR for version bumps instead of pushing to main

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,73 @@
+name: Tag release
+
+# When a version bump lands on `main` (via the PR opened by `version-bump.yml`),
+# create and push the matching `vX.Y.Z` git tag. This replaces the inline tagging
+# that `version-bump.yml` used to do before direct pushes to `main` were blocked
+# by branch protection.
+#
+# The job is idempotent: it only creates the tag if it doesn't already exist, so
+# unrelated pushes that touch `package.json` (e.g. dependency bumps) are no-ops.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - packages/grafana-llm-app/package.json
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get secrets from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
+        env:
+          VAULT_INSTANCE: ops
+        with:
+          vault_instance: ${{ env.VAULT_INSTANCE }}
+          # Don't export secrets to the job-wide environment; consume them via this
+          # step's `secrets` output only in the step that needs them (below).
+          export_env: false
+          common_secrets: |
+            GITHUB_APP_ID=plugins-platform-bot-app:app-id
+            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
+
+      - name: Generate GitHub token
+        id: generate-github-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
+          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          token: ${{ steps.generate-github-token.outputs.token }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - name: Setup Git
+        shell: bash
+        run: |
+          git config user.name 'grafana-plugins-platform-bot[bot]'
+          git config user.email '144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com'
+
+      - name: Create and push tag if version changed
+        shell: bash
+        run: |
+          VERSION=$(jq -r .version packages/grafana-llm-app/package.json)
+          TAG="v${VERSION}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists, nothing to do."
+            exit 0
+          fi
+          echo "Creating tag ${TAG}"
+          git tag -a "${TAG}" -m "Release version ${TAG}"
+          git push origin "${TAG}"
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -125,21 +125,23 @@ jobs:
         # are set up.
         working-directory: packages/grafana-llm-app
 
-      - name: Commit changes
+      # Direct pushes to `main` are blocked by branch protection, so we open a PR
+      # instead. The matching `vX.Y.Z` tag is created automatically once the PR is
+      # merged, by the `tag-release.yml` workflow.
+      - name: Create branch and open version bump PR
         shell: bash
         run: |
+          BRANCH="version-bump/${NEW_VERSION}"
+          git checkout -b "${BRANCH}"
           git add packages/grafana-llm-app/package.json packages/grafana-llm-frontend/package.json package-lock.json
           git add packages/grafana-llm-app/CHANGELOG.md || true  # No-op if changelog not generated
-          git commit -m "chore(version): bump version to ${{ steps.bump-plugin.outputs.new-version }}"
-          git push origin main
+          git commit -m "chore(version): bump version to ${NEW_VERSION}"
+          git push origin "${BRANCH}"
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "chore(version): bump version to ${NEW_VERSION}" \
+            --body "Automated version bump to \`${NEW_VERSION}\`. The matching git tag is created automatically once this PR is merged (see \`.github/workflows/tag-release.yml\`)."
         env:
-          GITHUB_TOKEN: ${{ steps.generate-github-token.outputs.token }}
-
-      - name: Create git tag
-        shell: bash
-        run: |
-          git tag -a ${{ steps.bump-plugin.outputs.new-version }} -m "Release version ${{ steps.bump-plugin.outputs.new-version }}"
-
-      - name: Push tags
-        shell: bash
-        run: git push origin --tags
+          NEW_VERSION: ${{ steps.bump-plugin.outputs.new-version }}
+          GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}


### PR DESCRIPTION
## What

Reworks the release-tagging flow so it no longer relies on the bot pushing directly to `main`:

- **`version-bump.yml`** — instead of committing the bump and tag straight to `main`, it now creates a `version-bump/<version>` branch, pushes it, and opens a PR (using the same plugins-platform-bot app token).
- **`tag-release.yml`** (new) — triggers on pushes to `main` that touch `packages/grafana-llm-app/package.json`, reads the version, and creates/pushes the `vX.Y.Z` tag if it doesn't already exist.

## Why

The `Version bump and update changelog` workflow currently fails at `git push origin main`:

```
remote: Permission to grafana/grafana-llm-app.git denied to grafana-plugins-platform-bot[bot].
fatal: ... error: 403
```

Branch protection no longer allows direct pushes to `main`. (#940 is the manual `v1.0.9` bump done while this was broken; this PR fixes the automation going forward.)

## How tagging works now

The git tag isn't a trigger for any workflow in this repo (publish/CD and npm-release are all `workflow_dispatch`; `push.yml` runs on push to `main`), so it's purely a release marker / `git describe` anchor. Moving it to a post-merge step is safe:

- When a version-bump PR merges, the bump commit lands on `main` → `tag-release.yml` runs → tag created.
- The step is **idempotent**: it skips if the tag already exists, so renovate/dependency PRs that touch `package.json` (without changing the `version` field) are harmless no-ops.

## Notes / assumptions

- Assumes the `plugins-platform-bot-app` GitHub App has **pull-requests: write** (needed for `gh pr create`) and that it *can* push non-`main` branches and tags (the 403 was specific to the protected `main` branch).
- `tag-release.yml` reuses the exact Vault + app-token pattern already in `version-bump.yml`, so zizmor findings are identical to what's already accepted on `main` (no new finding types). The version-bump edits also reduced a few `template-injection` infos by switching to env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)