### PR TITLE
chore: make grafanaDependency prerelease-inclusive

### DIFF
--- a/packages/grafana-llm-app/src/plugin.json
+++ b/packages/grafana-llm-app/src/plugin.json
@@ -28,7 +28,7 @@
   },
   "includes": [],
   "dependencies": {
-    "grafanaDependency": ">=9.5.2",
+    "grafanaDependency": ">=9.5.2-0",
     "plugins": []
   },
   "iam": {


### PR DESCRIPTION
grafana-com PR #17309 made the plugins publish API reject Grafana-owned plugins whose `grafanaDependency` lower bound isn't prerelease-inclusive, so the next publish of this plugin would fail.

This updates the range from `>=9.5.2` to `>=9.5.2-0` so prerelease Grafana builds are matched and publishing keeps working. No behavior change for released Grafana versions.

Ref: https://github.com/grafana/grafana-com/pull/17309