### PR TITLE
fix(e2e): bump Playwright Docker image to v1.61.0-noble

### DIFF
--- a/packages/grafana-llm-app/docker-compose.yaml
+++ b/packages/grafana-llm-app/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
 
   # Playwright server for interactive development
   playwright-server:
-    image: mcr.microsoft.com/playwright:v1.60.0-noble
+    image: mcr.microsoft.com/playwright:v1.61.0-noble
     container_name: 'playwright-server'
     working_dir: /app
     command: sh -c "npm install --legacy-peer-deps && npx playwright run-server --port 5000 --host 0.0.0.0"
@@ -77,7 +77,7 @@ services:
 
   # Playwright runner for CI/automated testing
   playwright-runner:
-    image: mcr.microsoft.com/playwright:v1.60.0-noble
+    image: mcr.microsoft.com/playwright:v1.61.0-noble
     container_name: 'playwright-runner'
     working_dir: /app
     command: sh -c "npm install --legacy-peer-deps && echo 'Waiting for Grafana to be ready...' && until curl -f http://grafana:3000/api/health; do echo 'Waiting for Grafana...'; sleep 2; done && echo 'Grafana is ready! Starting tests...' && npx playwright test"


### PR DESCRIPTION
## What

Bumps the Playwright Docker image in `packages/grafana-llm-app/docker-compose.yaml` from `v1.60.0-noble` to `v1.61.0-noble` (both `playwright-server` and `playwright-runner` services).

## Why

The Dockerized Playwright services run `npm install --legacy-peer-deps` at container start, which resolves `@playwright/test` (`^1.52.0`) to the latest 1.x — currently **1.61.0**. The image, however, was pinned to `v1.60.0-noble`, whose bundled browsers don't match. Playwright refuses to run on a version mismatch:

```
Error: browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1228/chrome-headless-shell-linux64/chrome-headless-shell
╔══════════════════════════════════════════════════════╗
║ -  current: mcr.microsoft.com/playwright:v1.60.0-noble ║
║ - required: mcr.microsoft.com/playwright:v1.61.0-noble ║
╚══════════════════════════════════════════════════════╝
```

This was failing the `tests` (Dockerized Playwright E2E) check on `main`, independent of any individual PR's changes (e.g. #947).

Follows the established manual-bump pattern (0b88237b, 3cba9c3a, 2629775a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)