### PR TITLE
fix(ci): scope create-github-app-token in version-bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -49,6 +49,11 @@ jobs:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          # Scope the token to this repository and to the only permission this
+          # workflow needs (pushing the version-bump commit and tags), rather
+          # than inheriting blanket access to every repo in the org install.
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
## What

Scopes the `actions/create-github-app-token` step in `.github/workflows/version-bump.yml` to:
- `repositories: ${{ github.event.repository.name }}` — this repo only
- `permission-contents: write` — the only permission the workflow uses

## Why

zizmor's `github-app` audit (now run at v1.25.2, **high** severity, which fails the build) flags two issues with this step, introduced when the action was bumped to v3.2.0 in #927:

```
error[github-app]: dangerous use of GitHub App tokens
  --> ./.github/workflows/version-bump.yml:51:11
   | owner: ${{ github.repository_owner }}
   | token granted access to all repositories for this owner's app installation
   = tip: use `repositories: 'repo1,repo2'` to scope the token to specific repositories

error[github-app]: dangerous use of GitHub App tokens
  --> ./.github/workflows/version-bump.yml:47:15
   | uses: actions/create-github-app-token@... # v3.2.0
   | app token inherits blanket installation permissions
   = tip: specify at least one `permission-<name>` input to limit the token's permissions
```

The workflow only uses the token to check out and `git push` the version-bump commit and tags, so `contents: write` scoped to this single repository is sufficient. This was failing the `zizmor` check on `main`, independent of any individual PR (e.g. #947).

🤖 Generated with [Claude Code](https://claude.com/claude-code)