### PR TITLE
fix(ci): unbreak E2E (Playwright image) and zizmor (app-token scope)

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -49,6 +49,11 @@ jobs:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          # Scope the token to this repository and to the only permission this
+          # workflow needs (pushing the version-bump commit and tags), rather
+          # than inheriting blanket access to every repo in the org install.
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/packages/grafana-llm-app/docker-compose.yaml
+++ b/packages/grafana-llm-app/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
 
   # Playwright server for interactive development
   playwright-server:
-    image: mcr.microsoft.com/playwright:v1.60.0-noble
+    image: mcr.microsoft.com/playwright:v1.61.0-noble
     container_name: 'playwright-server'
     working_dir: /app
     command: sh -c "npm install --legacy-peer-deps && npx playwright run-server --port 5000 --host 0.0.0.0"
@@ -77,7 +77,7 @@ services:
 
   # Playwright runner for CI/automated testing
   playwright-runner:
-    image: mcr.microsoft.com/playwright:v1.60.0-noble
+    image: mcr.microsoft.com/playwright:v1.61.0-noble
     container_name: 'playwright-runner'
     working_dir: /app
     command: sh -c "npm install --legacy-peer-deps && echo 'Waiting for Grafana to be ready...' && until curl -f http://grafana:3000/api/health; do echo 'Waiting for Grafana...'; sleep 2; done && echo 'Grafana is ready! Starting tests...' && npx playwright test"


### PR DESCRIPTION
Combines two independent CI fixes into one PR, since both the `tests` and `zizmor` checks are required and currently failing on `main` — neither fix alone turns CI green.

Supersedes #948 and #949.

## 1. Playwright E2E — image/npm version mismatch

Bumps the Playwright Docker image (`packages/grafana-llm-app/docker-compose.yaml`, both services) from `v1.60.0-noble` to `v1.61.0-noble`.

The Dockerized Playwright services run `npm install --legacy-peer-deps` at start, resolving `@playwright/test` (`^1.52.0`) to the latest 1.x — currently **1.61.0** — which doesn't match the pinned `v1.60.0` image. Playwright refuses to run on a mismatch:

```
Error: browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1228/...
║ -  current: mcr.microsoft.com/playwright:v1.60.0-noble ║
║ - required: mcr.microsoft.com/playwright:v1.61.0-noble ║
```

Follows the established manual-bump pattern (0b88237b, 3cba9c3a, 2629775a).

## 2. zizmor — unscoped GitHub App token

Scopes the `actions/create-github-app-token` step in `.github/workflows/version-bump.yml` to `repositories: ${{ github.event.repository.name }}` and `permission-contents: write`.

zizmor v1.25.2's `github-app` audit (**high** severity, fails the build) flags two issues introduced when the action was bumped to v3.2.0 in #927:

```
error[github-app]: dangerous use of GitHub App tokens
  --> version-bump.yml:51 | owner without repositories → access to all repos in the installation
  --> version-bump.yml:47 | no permission-* inputs → blanket installation permissions
```

The workflow only uses the token to check out and `git push` the bump commit and tags, so `contents: write` scoped to this repo is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)