### PR TITLE
fix: return after writing error responses in resource handlers

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/resources.go
+++ b/packages/grafana-llm-app/pkg/plugin/resources.go
@@ -438,6 +438,7 @@ func (a *App) handleModels() http.HandlerFunc {
 		if err != nil {
 			log.DefaultLogger.Error("LLM provider has invalid configuration", "err", err)
 			handleError(w, errors.New("LLM provider has invalid configuration"), http.StatusUnprocessableEntity)
+			return
 		}
 		if llmProvider == nil {
 			handleError(w, errors.New("must configure an LLM provider"), http.StatusUnprocessableEntity)
@@ -450,6 +451,7 @@ func (a *App) handleModels() http.HandlerFunc {
 		models, err := llmProvider.Models(r.Context())
 		if errors.Is(err, errBadRequest) {
 			handleError(w, err, http.StatusBadRequest)
+			return
 		} else if err != nil {
 			handleError(w, err, http.StatusInternalServerError)
 			return
@@ -547,6 +549,7 @@ func (a *App) handleChatCompletions() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			handleError(w, errors.New("LLM provider has invalid configuration"), http.StatusUnprocessableEntity)
+			return
 		}
 		if llmProvider == nil {
 			handleError(w, errors.New("must configure an LLM provider"), http.StatusUnprocessableEntity)
@@ -576,6 +579,7 @@ func (a *App) handleChatCompletions() http.HandlerFunc {
 		resp, err := llmProvider.ChatCompletion(r.Context(), req)
 		if errors.Is(err, errBadRequest) {
 			handleError(w, err, http.StatusBadRequest)
+			return
 		} else if err != nil {
 			handleError(w, err, http.StatusInternalServerError)
 			return

--- a/packages/grafana-llm-app/pkg/plugin/resources_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/resources_test.go
@@ -838,3 +838,80 @@ func withProviderURL(t *testing.T, s backend.AppInstanceSettings, url string) ba
 	}
 	return s
 }
+
+// TestErrorResponsesAreSingleJSONDocument ensures the chat completions and
+// models handlers write exactly one JSON document on error paths. The error
+// branches previously fell through after handleError, appending a zero-value
+// success payload (or a second error) to the response body, which corrupted
+// the JSON received by clients.
+func TestErrorResponsesAreSingleJSONDocument(t *testing.T) {
+	ctx := context.Background()
+
+	// decodeSingleJSON asserts body contains exactly one JSON document.
+	decodeSingleJSON := func(t *testing.T, body []byte) map[string]any {
+		t.Helper()
+		dec := json.NewDecoder(bytes.NewReader(body))
+		var doc map[string]any
+		require.NoError(t, dec.Decode(&doc), "body is not valid JSON: %s", body)
+		require.False(t, dec.More(), "body contains more than one JSON document: %s", body)
+		return doc
+	}
+
+	for _, tc := range []struct {
+		name      string
+		settings  backend.AppInstanceSettings
+		method    string
+		path      string
+		body      []byte
+		expStatus int
+	}{
+		{
+			name: "chat completions: azure model with no deployment mapping",
+			settings: backend.AppInstanceSettings{
+				JSONData: []byte(`{"provider": "azure", "openAI": {"url": "https://example.openai.azure.com", "azureModelMapping": [["gpt-4", "gpt-4-deployment"]]}}`),
+				DecryptedSecureJSONData: map[string]string{
+					openAIKey: "abcd1234",
+				},
+			},
+			method:    http.MethodPost,
+			path:      "/llm/v1/chat/completions",
+			body:      []byte(`{"model": "base", "messages": [{"role": "user", "content": "hi"}]}`),
+			expStatus: http.StatusBadRequest,
+		},
+		{
+			name:      "chat completions: no provider configured",
+			settings:  backend.AppInstanceSettings{JSONData: []byte(`{}`)},
+			method:    http.MethodPost,
+			path:      "/llm/v1/chat/completions",
+			body:      []byte(`{"model": "base", "messages": [{"role": "user", "content": "hi"}]}`),
+			expStatus: http.StatusUnprocessableEntity,
+		},
+		{
+			name:      "models: no provider configured",
+			settings:  backend.AppInstanceSettings{JSONData: []byte(`{}`)},
+			method:    http.MethodGet,
+			path:      "/llm/v1/models",
+			expStatus: http.StatusUnprocessableEntity,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inst, err := NewApp(ctx, tc.settings)
+			require.NoError(t, err)
+			app, ok := inst.(*App)
+			require.True(t, ok, "inst must be of type *App")
+
+			var r mockCallResourceResponseSender
+			err = app.CallResource(ctx, &backend.CallResourceRequest{
+				Method: tc.method,
+				Path:   tc.path,
+				Body:   tc.body,
+			}, &r)
+			require.NoError(t, err)
+			require.NotNil(t, r.response)
+
+			require.Equal(t, tc.expStatus, r.response.Status)
+			doc := decodeSingleJSON(t, r.response.Body)
+			require.Contains(t, doc, "error")
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Four error branches in `resources.go` write an error response via `handleError` and then fall through instead of returning: the `createProvider` error and `errBadRequest` branches in both `handleModels` and `handleChatCompletions`. The handler then continues and writes a second JSON document into the same response body.

The easiest way to hit this is the Azure provider with a model that has no deployment mapping. The client receives:

```
{"error":"bad request: no deployment found for model: base"}{"id":"","object":"","created":0,...}
```

which is the 400 error followed by a marshaled zero-value completion, so anything parsing the body as JSON fails. With no provider configured, both handlers return two concatenated error documents instead.

## Fix

Add the missing `return` after each of the four `handleError` calls. No behavior change on success paths; error responses are now exactly one JSON document.

## Verification

Ran in a clean golang:1.26 container: the new regression test `TestErrorResponsesAreSingleJSONDocument` (three cases, driven through `CallResource` like the existing `TestCallResource`) fails on current main with the corrupted bodies shown above, and passes with this change. The full `./pkg/...` suite passes and `go vet` is clean.

For transparency: I used an AI assistant to find, fix, and verify this; the outputs above are from actual test runs.
