### PR TITLE
chore(version): bump version to v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19797,7 +19797,7 @@
     },
     "packages/grafana-llm-app": {
       "name": "@grafana/llm-app",
-      "version": "1.0.9",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.13.5",
@@ -19995,7 +19995,7 @@
     },
     "packages/grafana-llm-frontend": {
       "name": "@grafana/llm",
-      "version": "1.0.9",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/packages/grafana-llm-app/CHANGELOG.md
+++ b/packages/grafana-llm-app/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+#### 1.1.0
+
+##### Chores
+
+* **deps:**  update to Grafana 13 packages (#962) (cfce0db9)
+*  make grafanaDependency prerelease-inclusive (#947) (92f56b20)
+
+##### Bug Fixes
+
+* **deps:**  update vulnerable dependencies to patched versions (#955) (b4786316)
+* **security:**  apply pending dependency security fixes (#963) (d6e8746a)
+* **ci:**  unbreak E2E (Playwright image) and zizmor (app-token scope) (#950) (585fba7a)
+*  include gcom response message in error text (#954) (80735596)
+
 #### 1.0.9
 
 ##### Chores

--- a/packages/grafana-llm-app/package.json
+++ b/packages/grafana-llm-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/llm-app",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "private": true,
   "description": "Plugin to easily allow llm based extensions to grafana",
   "scripts": {

--- a/packages/grafana-llm-frontend/package.json
+++ b/packages/grafana-llm-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/llm",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "A library for working with LLMs in Grafana plugins",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Minor release covering the Grafana 13 package update, dependency security fixes, and CI repairs merged since v1.0.9:

  - chore(deps): update to Grafana 13 packages (#962)
  - chore: make grafanaDependency prerelease-inclusive (#947)
  - fix(deps): update vulnerable dependencies to patched versions (#955)
  - fix(security): apply pending dependency security fixes (#963)
  - fix(ci): unbreak E2E (Playwright image) and zizmor (app-token scope) (#950)
  - Include gcom response message in error text (#954)