### PR TITLE
docs: note OpenAI-compatible multi-model gateway (custom provider)

### DIFF
--- a/packages/grafana-llm-app/README.md
+++ b/packages/grafana-llm-app/README.md
@@ -56,6 +56,24 @@ apps:
       openAIKey: $OPENAI_API_KEY
 ```
 
+### Using an OpenAI-compatible multi-model gateway
+
+The plugin can talk to OpenAI-compatible multi-model gateways via `provider: custom` and `openAI.url` (the default API path `/v1` is appended). For example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=docs_pr):
+
+```yaml
+apiVersion: 1
+
+apps:
+  - type: 'grafana-llm-app'
+    disabled: false
+    jsonData:
+      provider: custom
+      openAI:
+        url: https://api.daoxe.com
+    secureJsonData:
+      openAIKey: $OPENAI_API_KEY
+```
+
 ### Using Azure OpenAI
 
 To provision the plugin to use Azure OpenAI, use settings similar to this:

--- a/packages/grafana-llm-app/README.md
+++ b/packages/grafana-llm-app/README.md
@@ -58,7 +58,7 @@ apps:
 
 ### Using an OpenAI-compatible multi-model gateway
 
-The plugin can talk to OpenAI-compatible multi-model gateways via `provider: custom` and `openAI.url` (the default API path `/v1` is appended). For example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=docs_pr):
+The plugin can talk to OpenAI-compatible multi-model gateways via `provider: custom` and `openAI.url` (the default API path `/v1` is appended). For example [DaoXE](https://daoxe.com):
 
 ```yaml
 apiVersion: 1


### PR DESCRIPTION
## Summary

The LLM app already supports `provider: custom` with a configurable `openAI.url` (default API path `/v1`).

This PR documents that pattern for OpenAI-compatible multi-model gateways, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan

- [ ] YAML matches existing provisioning style
- [ ] URL is origin-only (`https://api.daoxe.com`) so default `/v1` path still applies
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>