### PR TITLE
fix(llmclient): bound health-check response read with io.LimitReader

### DIFF
--- a/llmclient/llmclient.go
+++ b/llmclient/llmclient.go
@@ -129,7 +129,7 @@ func (o *llmProvider) Enabled(ctx context.Context) (bool, error) {
 	if resp.StatusCode != http.StatusOK {
 		return false, nil
 	}
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
 	if err != nil {
 		return false, fmt.Errorf("read response body: %w", err)
 	}

--- a/llmclient/llmclient_test.go
+++ b/llmclient/llmclient_test.go
@@ -1,12 +1,14 @@
 package llmclient
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sashabaranov/go-openai"
@@ -137,4 +139,63 @@ func TestChatCompletionsStream(t *testing.T) {
 	if content != "hello there" {
 		t.Errorf("expected streamed content to be 'hello there', got '%s'", content)
 	}
+}
+
+func TestEnabled_LimitsResponseBodyRead(t *testing.T) {
+	ctx := context.Background()
+	key := "test"
+	const oversized = 5 * 1024 * 1024 // 5MiB, well over the intended read cap
+	filler := bytes.Repeat([]byte("x"), oversized)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/plugins/grafana-llm-app/health" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// Not valid JSON in either the new or old health response shape, so Enabled
+		// is expected to return an error regardless of how much of it gets read.
+		w.WriteHeader(http.StatusOK)
+		w.Write(filler)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	var bytesRead int64
+	transport := &countingTransport{base: http.DefaultTransport, read: &bytesRead}
+	client := NewLLMProviderWithClient(server.URL, key, &http.Client{Transport: transport})
+
+	_, err := client.Enabled(ctx)
+	if err == nil {
+		t.Fatal("expected an error unmarshalling the oversized non-JSON health response, got nil")
+	}
+	// The read must be capped well below the full response size; otherwise a slow or
+	// malicious upstream health response can force this client to buffer it all in memory.
+	const cap = 2 * 1024 * 1024 // generous slack above the 1MiB limit
+	if bytesRead > cap {
+		t.Fatalf("Enabled read %d bytes of the response body, want capped near 1MiB (< %d)", bytesRead, cap)
+	}
+}
+
+type countingTransport struct {
+	base http.RoundTripper
+	read *int64
+}
+
+func (t *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	resp.Body = &countingReadCloser{ReadCloser: resp.Body, read: t.read}
+	return resp, nil
+}
+
+type countingReadCloser struct {
+	io.ReadCloser
+	read *int64
+}
+
+func (c *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := c.ReadCloser.Read(p)
+	atomic.AddInt64(c.read, int64(n))
+	return n, err
 }


### PR DESCRIPTION
## What this does

`llmProvider.Enabled()` reads the app's own health-check response with a plain `io.ReadAll(resp.Body)`, with no size limit. Wraps it in `io.LimitReader(resp.Body, 1024*1024)`, matching the limit already used for the same purpose in `vectorapi.go`, `embed/openai.go`, and `resources.go`.

Fixes #307, filed by @matryer: "just in case, we should consider an `io.LimitReader` here. Otherwise it could hang here for ages/ever."

## Testing

- New regression test (`TestEnabled_LimitsResponseBodyRead`) wraps the HTTP transport with a byte counter and serves a 5MiB non-JSON health response: fails on main (reads all 5MiB), passes on this branch (read capped near 1MiB).
- Full `llmclient` package suite: `go test ./...` green (Go 1.26, matching `go.mod`).
- `gofmt -l` and `go vet ./...` clean.
- `llmclient/` has no CI workflow of its own in this repo (only `packages/grafana-llm-app` is wired into `run-tests.yml`/`is-compatible.yml`/`push.yml`), so the package's own test suite above is the only gate that applies to this change.