### PR TITLE
fix: use completion token limits for reasoning models

### DIFF
--- a/packages/grafana-llm-app/pkg/plugin/azure_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/azure_provider.go
@@ -74,6 +74,7 @@ func (p *azure) ChatCompletion(ctx context.Context, req ChatCompletionRequest) (
 
 	r := req.ChatCompletionRequest
 	r.Model = deployment
+	useMaxCompletionTokens(&r)
 
 	ForceUserMessage(&r)
 
@@ -94,6 +95,7 @@ func (p *azure) ChatCompletionStream(ctx context.Context, req ChatCompletionRequ
 	r := req.ChatCompletionRequest
 	// For the Azure mapping we want to use the name of the mapped deployment as the model.
 	r.Model = deployment
+	useMaxCompletionTokens(&r)
 
 	ForceUserMessage(&r)
 

--- a/packages/grafana-llm-app/pkg/plugin/llm_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/llm_provider.go
@@ -77,6 +77,23 @@ func (m Model) toProvider(provider ProviderType, modelSettings *ModelSettings) s
 	return modelSettings.getModel(m)
 }
 
+// useMaxCompletionTokens converts max_tokens only when go-openai rejects it
+// for the resolved model. Other reasoning-model validation errors still flow
+// through unchanged when the provider sends the request.
+func useMaxCompletionTokens(r *openai.ChatCompletionRequest) {
+	if r.MaxTokens == 0 || !errors.Is(
+		openai.NewReasoningValidator().Validate(*r),
+		openai.ErrReasoningModelMaxTokensDeprecated,
+	) {
+		return
+	}
+
+	if r.MaxCompletionTokens == 0 {
+		r.MaxCompletionTokens = r.MaxTokens
+	}
+	r.MaxTokens = 0
+}
+
 type ChatCompletionRequest struct {
 	openai.ChatCompletionRequest
 	Model Model `json:"model"`

--- a/packages/grafana-llm-app/pkg/plugin/openai_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/openai_provider.go
@@ -57,6 +57,7 @@ func (p *openAI) Models(ctx context.Context) (ModelResponse, error) {
 func (p *openAI) ChatCompletion(ctx context.Context, req ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
 	r := req.ChatCompletionRequest
 	r.Model = req.Model.toOpenAI(p.models)
+	useMaxCompletionTokens(&r)
 
 	ForceUserMessage(&r)
 
@@ -71,6 +72,7 @@ func (p *openAI) ChatCompletion(ctx context.Context, req ChatCompletionRequest) 
 func (p *openAI) ChatCompletionStream(ctx context.Context, req ChatCompletionRequest) (<-chan ChatCompletionStreamResponse, error) {
 	r := req.ChatCompletionRequest
 	r.Model = req.Model.toOpenAI(p.models)
+	useMaxCompletionTokens(&r)
 
 	ForceUserMessage(&r)
 

--- a/packages/grafana-llm-app/pkg/plugin/openai_tokens_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/openai_tokens_test.go
@@ -1,0 +1,146 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIProviders_MaxTokensOutboundJSON(t *testing.T) {
+	tests := []struct {
+		name                        string
+		model                       string
+		maxTokens                   int
+		maxCompletionTokens         int
+		expectedMaxTokens           int
+		expectedMaxCompletionTokens int
+	}{
+		{
+			name:                        "GPT-5 converts max_tokens",
+			model:                       "gpt-5.4-mini",
+			maxTokens:                   100,
+			expectedMaxCompletionTokens: 100,
+		},
+		{
+			name:                        "GPT-5 preserves caller-supplied max_completion_tokens",
+			model:                       "gpt-5.4-mini",
+			maxTokens:                   100,
+			maxCompletionTokens:         200,
+			expectedMaxCompletionTokens: 200,
+		},
+		{
+			name:              "older model preserves max_tokens",
+			model:             "gpt-4.1-mini",
+			maxTokens:         100,
+			expectedMaxTokens: 100,
+		},
+	}
+
+	providers := []struct {
+		name string
+		new  func(t *testing.T, serverURL, model string) LLMProvider
+	}{
+		{
+			name: "OpenAI-compatible",
+			new: func(t *testing.T, serverURL, model string) LLMProvider {
+				t.Helper()
+				apiPath := "/v1"
+				provider, err := NewOpenAIProvider(OpenAISettings{
+					URL:     serverURL,
+					APIPath: &apiPath,
+					apiKey:  "test-key",
+				}, &ModelSettings{
+					Default: ModelBase,
+					Mapping: map[Model]string{ModelBase: model},
+				})
+				require.NoError(t, err)
+				return provider
+			},
+		},
+		{
+			name: "Azure",
+			new: func(t *testing.T, serverURL, model string) LLMProvider {
+				t.Helper()
+				provider, err := NewAzureProvider(OpenAISettings{
+					URL:          serverURL,
+					apiKey:       "test-key",
+					AzureMapping: [][]string{{ModelBase, model}},
+				}, ModelBase)
+				require.NoError(t, err)
+				return provider
+			},
+		},
+	}
+
+	for _, providerTest := range providers {
+		for _, stream := range []bool{false, true} {
+			pathName := "non-streaming"
+			if stream {
+				pathName = "streaming"
+			}
+			for _, tt := range tests {
+				t.Run(providerTest.name+"/"+pathName+"/"+tt.name, func(t *testing.T) {
+					var outbound map[string]json.RawMessage
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if err := json.NewDecoder(r.Body).Decode(&outbound); err != nil {
+							t.Errorf("decode outbound request: %v", err)
+							http.Error(w, "invalid request", http.StatusBadRequest)
+							return
+						}
+						if stream {
+							w.Header().Set("Content-Type", "text/event-stream")
+							_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+							return
+						}
+						_ = json.NewEncoder(w).Encode(openai.ChatCompletionResponse{ID: "test"})
+					}))
+					defer server.Close()
+
+					provider := providerTest.new(t, server.URL, tt.model)
+					req := ChatCompletionRequest{
+						Model: ModelBase,
+						ChatCompletionRequest: openai.ChatCompletionRequest{
+							Messages: []openai.ChatCompletionMessage{{
+								Role:    openai.ChatMessageRoleUser,
+								Content: "test",
+							}},
+							MaxTokens:           tt.maxTokens,
+							MaxCompletionTokens: tt.maxCompletionTokens,
+						},
+					}
+
+					if stream {
+						responses, err := provider.ChatCompletionStream(context.Background(), req)
+						require.NoError(t, err)
+						for range responses {
+						}
+					} else {
+						_, err := provider.ChatCompletion(context.Background(), req)
+						require.NoError(t, err)
+					}
+
+					assertJSONInteger(t, outbound, "max_tokens", tt.expectedMaxTokens)
+					assertJSONInteger(t, outbound, "max_completion_tokens", tt.expectedMaxCompletionTokens)
+				})
+			}
+		}
+	}
+}
+
+func assertJSONInteger(t *testing.T, body map[string]json.RawMessage, field string, expected int) {
+	t.Helper()
+	value, ok := body[field]
+	if expected == 0 {
+		assert.False(t, ok, "%s should be omitted from outbound JSON", field)
+		return
+	}
+	require.True(t, ok, "%s should be present in outbound JSON", field)
+	assert.JSONEq(t, fmt.Sprintf("%d", expected), string(value))
+}


### PR DESCRIPTION
## Summary

- translate legacy `max_tokens` to `max_completion_tokens` when the resolved OpenAI/Azure model is rejected by `go-openai`'s reasoning-model validator
- preserve an explicitly supplied `max_completion_tokens` value and omit the incompatible legacy field
- keep `max_tokens` unchanged for older compatible models
- cover OpenAI-compatible and Azure providers across streaming and non-streaming requests by asserting the actual outbound JSON

## Why

`go-openai` rejects GPT-5 and other recognized reasoning-model requests before sending them when `MaxTokens` is non-zero. Existing Grafana LLM clients commonly send `max_tokens`, so newer Azure Foundry/OpenAI-compatible deployments fail before an HTTP request is made.

The compatibility shim asks the pinned library's own `ReasoningValidator` whether the resolved deployment/model rejects `max_tokens`. This avoids duplicating its model-family list and leaves all unrelated reasoning validation errors unchanged.

## Compatibility

- recognized reasoning model + only `max_tokens`: move the value to `max_completion_tokens`
- recognized reasoning model + both fields: keep the caller's `max_completion_tokens`, omit `max_tokens`
- older model: preserve `max_tokens` exactly as before

## Verification

- focused provider matrix under `go test -race`: passed
- `go test ./... -count=1`: passed
- `go vet ./...`: passed
- `golangci-lint run ./...`: 0 issues (local 2.11.3; CI pins 2.11.4)
- `gofmt` and `git diff --check`

Closes #992
