### PR TITLE
feat: support configurable Azure API versions

### DIFF
--- a/packages/grafana-llm-app/README.md
+++ b/packages/grafana-llm-app/README.md
@@ -70,6 +70,7 @@ apps:
       provider: azure
       openAI:
         url: https://<resource>.openai.azure.com
+        apiVersion: "2024-10-21"
         azureModelMapping:
           - ["base", "gpt-35-turbo"]
           - ["large", "gpt-4-turbo"]
@@ -80,6 +81,7 @@ apps:
 where:
 
 - `<resource>` is your Azure OpenAI resource name
+- `apiVersion` is optional; omit it to use the `go-openai` SDK default
 - the `azureModelMapping` field contains `[model, deployment]` pairs so that features know
   which Azure deployment to use in place of each model you wish to be used.
 
@@ -141,6 +143,7 @@ apps:
       # provider: azure
       # openAI:
       #   url: https://<resource>.openai.azure.com
+      #   apiVersion: "2024-10-21"
       #   azureModelMapping:
       #     - ["gpt-3.5-turbo", "gpt-35-turbo"]
       vector:

--- a/packages/grafana-llm-app/pkg/plugin/azure_provider.go
+++ b/packages/grafana-llm-app/pkg/plugin/azure_provider.go
@@ -30,6 +30,9 @@ func NewAzureProvider(settings OpenAISettings, defaultModel Model) (LLMProvider,
 	log.DefaultLogger.Debug("Using Azure OpenAI", "url", settings.URL)
 	cfg := openai.DefaultAzureConfig(settings.apiKey, settings.URL)
 	cfg.HTTPClient = client
+	if settings.APIVersion != "" {
+		cfg.APIVersion = settings.APIVersion
+	}
 	// We pass the deployment as the name of the model, so just return the untransformed string.
 	cfg.AzureModelMapperFunc = func(model string) string {
 		return model

--- a/packages/grafana-llm-app/pkg/plugin/azure_provider_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/azure_provider_test.go
@@ -1,0 +1,72 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzureProviderAPIVersion(t *testing.T) {
+	defaultVersion := openai.DefaultAzureConfig("", "").APIVersion
+	for _, stream := range []bool{false, true} {
+		pathName := "non-streaming"
+		if stream {
+			pathName = "streaming"
+		}
+		for _, tt := range []struct {
+			name            string
+			configured      string
+			expectedVersion string
+		}{
+			{name: "uses SDK default when unset", expectedVersion: defaultVersion},
+			{name: "uses configured version", configured: "2024-10-21", expectedVersion: "2024-10-21"},
+		} {
+			t.Run(pathName+"/"+tt.name, func(t *testing.T) {
+				var receivedVersion string
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					receivedVersion = r.URL.Query().Get("api-version")
+					if stream {
+						w.Header().Set("Content-Type", "text/event-stream")
+						_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+						return
+					}
+					_ = json.NewEncoder(w).Encode(openai.ChatCompletionResponse{ID: "test"})
+				}))
+				defer server.Close()
+
+				provider, err := NewAzureProvider(OpenAISettings{
+					URL:          server.URL,
+					APIVersion:   tt.configured,
+					apiKey:       "test-key",
+					AzureMapping: [][]string{{ModelBase, "deployment"}},
+				}, ModelBase)
+				require.NoError(t, err)
+
+				req := ChatCompletionRequest{
+					Model: ModelBase,
+					ChatCompletionRequest: openai.ChatCompletionRequest{
+						Messages: []openai.ChatCompletionMessage{{Role: openai.ChatMessageRoleUser, Content: "test"}},
+					},
+				}
+				if stream {
+					responses, err := provider.ChatCompletionStream(context.Background(), req)
+					require.NoError(t, err)
+					for range responses {
+					}
+				} else {
+					_, err := provider.ChatCompletion(context.Background(), req)
+					require.NoError(t, err)
+				}
+
+				assert.Equal(t, tt.expectedVersion, receivedVersion)
+			})
+		}
+	}
+}

--- a/packages/grafana-llm-app/pkg/plugin/settings.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings.go
@@ -55,6 +55,9 @@ type OpenAISettings struct {
 	// Model mappings required for Azure's OpenAI
 	AzureMapping [][]string `json:"azureModelMapping"`
 
+	// Optional Azure OpenAI API version. When empty, go-openai's default is used.
+	APIVersion string `json:"apiVersion,omitempty"`
+
 	// Disabled marks if a user has explicitly disabled LLM functionality.
 	// Deprecated: Use Settings.Disabled instead
 	Disabled bool `json:"disabled"`

--- a/packages/grafana-llm-app/pkg/plugin/settings_test.go
+++ b/packages/grafana-llm-app/pkg/plugin/settings_test.go
@@ -7,6 +7,18 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
+func TestLoadSettingsAzureAPIVersion(t *testing.T) {
+	settings, err := loadSettings(backend.AppInstanceSettings{
+		JSONData: []byte(`{"provider":"azure","openAI":{"apiVersion":"2024-10-21"}}`),
+	})
+	if err != nil {
+		t.Fatalf("loadSettings failed: %s", err)
+	}
+	if settings.OpenAI.APIVersion != "2024-10-21" {
+		t.Fatalf("expected Azure API version to round-trip, got %q", settings.OpenAI.APIVersion)
+	}
+}
+
 func TestEmbeddingSettingLogic(t *testing.T) {
 
 	// Set up and run test cases

--- a/packages/grafana-llm-app/src/components/AppConfig/OpenAI.test.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/OpenAI.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { testIds } from '../testIds';
+import { OpenAIConfig, OpenAISettings } from './OpenAI';
+
+describe('OpenAIConfig Azure API version', () => {
+  it('shows and updates the optional version for Azure', () => {
+    const onChange = jest.fn<void, [OpenAISettings]>();
+    render(
+      <OpenAIConfig
+        settings={{ provider: 'azure', apiVersion: '2024-08-01-preview' }}
+        secrets={{}}
+        secretsSet={{}}
+        onChange={onChange}
+        onChangeSecrets={() => {}}
+        allowCustomPath={false}
+      />
+    );
+
+    const input = screen.getByTestId(testIds.appConfig.azureOpenAIApiVersion);
+    expect((input as HTMLInputElement).value).toBe('2024-08-01-preview');
+
+    fireEvent.change(input, { target: { value: ' 2024-10-21 ' } });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ apiVersion: '2024-10-21' }));
+  });
+
+  it('does not show the Azure version for OpenAI', () => {
+    render(
+      <OpenAIConfig
+        settings={{ provider: 'openai' }}
+        secrets={{}}
+        secretsSet={{}}
+        onChange={() => {}}
+        onChangeSecrets={() => {}}
+        allowCustomPath={false}
+      />
+    );
+
+    expect(screen.queryByTestId(testIds.appConfig.azureOpenAIApiVersion)).toBeNull();
+  });
+});

--- a/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
+++ b/packages/grafana-llm-app/src/components/AppConfig/OpenAI.tsx
@@ -23,6 +23,8 @@ export interface OpenAISettings {
   provider?: ProviderType;
   // A mapping of OpenAI models to Azure deployment names.
   azureModelMapping?: AzureModelDeployments;
+  // Optional Azure OpenAI API version. The SDK default is used when omitted.
+  apiVersion?: string;
   // If the LLM features have been explicitly disabled.
   disabled?: boolean;
 }
@@ -178,18 +180,34 @@ export function OpenAIConfig({
       )}
 
       {effectiveProvider === 'azure' && (
-        <Field label="Azure OpenAI Model Mapping" description="Mapping from model name to Azure deployment name.">
-          <AzureModelDeploymentConfig
-            modelMapping={settings.azureModelMapping ?? []}
-            modelNames={Object.values(openai.Model)}
-            onChange={(azureModelMapping) =>
-              onChange({
-                ...settings,
-                azureModelMapping,
-              })
-            }
-          />
-        </Field>
+        <>
+          <Field
+            label="Azure OpenAI API version"
+            description="Optional. Leave blank to use the SDK default."
+            className={s.marginTop}
+          >
+            <Input
+              width={60}
+              name="apiVersion"
+              data-testid={testIds.appConfig.azureOpenAIApiVersion}
+              value={settings.apiVersion ?? ''}
+              placeholder="2024-10-21"
+              onChange={onChangeField}
+            />
+          </Field>
+          <Field label="Azure OpenAI Model Mapping" description="Mapping from model name to Azure deployment name.">
+            <AzureModelDeploymentConfig
+              modelMapping={settings.azureModelMapping ?? []}
+              modelNames={Object.values(openai.Model)}
+              onChange={(azureModelMapping) =>
+                onChange({
+                  ...settings,
+                  azureModelMapping,
+                })
+              }
+            />
+          </Field>
+        </>
       )}
     </FieldSet>
   );

--- a/packages/grafana-llm-app/src/components/testIds.ts
+++ b/packages/grafana-llm-app/src/components/testIds.ts
@@ -7,6 +7,7 @@ export const testIds = {
     openAIApiPath: 'ac-openai-api-path',
     openAIOrganizationID: 'ac-openai-api-organization-id',
     openAIUrl: 'ac-openai-api-url',
+    azureOpenAIApiVersion: 'ac-azure-openai-api-version',
     anthropicKey: 'ac-anthropic-api-key',
     anthropicUrl: 'ac-anthropic-api-url',
     vectorEnabled: 'ac-vector-enabled',


### PR DESCRIPTION
## Summary

- add an optional `openAI.apiVersion` setting for Azure OpenAI
- expose the setting in the Azure configuration UI and provisioning documentation
- apply it to `go-openai`'s Azure client only when non-empty, preserving the SDK default otherwise
- cover UI visibility/editing, settings JSON round-trip, and the actual `api-version` query parameter for streaming and non-streaming requests

## Why

Azure OpenAI deployments can require a different API version from the one currently hardcoded by the client library. The plugin had no way to select that version, so otherwise valid deployments could not be used without changing the dependency.

The setting is intentionally optional and free-form. Azure version identifiers evolve (including dated and preview forms), while the SDK safely URL-encodes the query value. Leaving the field blank retains the exact existing behavior.

## Verification

- frontend Jest: 3/3 suites, 5 tests passed
- frontend TypeScript, ESLint, and Prettier checks passed
- focused Azure transport/settings tests under `go test -race` passed
- `go test ./... -count=1` passed
- `go vet ./...` passed
- `golangci-lint run ./...`: 0 issues
- `gofmt` and `git diff --check`

Closes #858
